### PR TITLE
Add support for docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+__pycache__
+.venv
+.env
+.nox
+.mypy_cache

--- a/.example.env
+++ b/.example.env
@@ -1,17 +1,17 @@
 # Bot token used to connect to Discord
-DISCORD_TOKEN=abc123
+HOM_DISCORD_TOKEN=abc123
 
 # The ID of the channel where tickets are created from
-SUPPORT_CHANNEL=456
+HOM_SUPPORT_CHANNEL=456
 
 # The ID of the category tickets should be created in
-TICKET_CATEGORY=789
+HOM_TICKET_CATEGORY=789
 
 # The ID of the moderator role
-MOD_ROLE=101
+HOM_MOD_ROLE=101
 
 # The ID of the channel to send ticket logs to
-MOD_LOG_CHANNEL=202
+HOM_MOD_LOG_CHANNEL=202
 
 # The ID of the general questions channel
-QUESTIONS_CHANNEL=303
+HOM_QUESTIONS_CHANNEL=303

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,38 @@
+name: Build and deploy HOM
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Login to Docker Hub
+        run: docker login -u ${{ secrets.ORG_DOCKER_USERNAME }} -p ${{ secrets.ORG_DOCKER_PASSWORD }}
+
+      - name: Build & Push the Docker image
+        run: |
+          docker build . --file dockerfile.prod --tag wiseoldman/hom:latest
+          docker push wiseoldman/hom:latest
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - name: Restart docker
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.DO_HOST }}
+          username: ${{ secrets.DO_USER }}
+          passphrase: ${{ secrets.DO_SSH_PASS }}
+          key: ${{ secrets.DO_SSH_KEY }}
+          script: |
+            cd wise-old-man
+            docker image rm wiseoldman/hom
+            docker-compose pull hom-bot
+            docker-compose up -d --no-deps --build hom-bot

--- a/README.md
+++ b/README.md
@@ -40,6 +40,21 @@ $ python -m hom
 Once the bot is running, make sure to run the `!sync` command in your dev server.
 This syncs the bots application commands with Discord.
 
+## Contributing with Docker
+
+You can also run the bot inside docker with hot reloading. It is still
+recommended to have have python and the bot's dependencies installed for
+compatibility with your linter.
+
+Still make sure to copy the `.env` file and that your discord bot application
+has proper perms in the developer dashboard.
+
+```sh
+$ docker-compose up
+```
+
+Every time you save a python file in the `hom` directory, the bot will restart.
+
 ## License
 
 Helpful Old Man is licensed under the [MIT License]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "3"
+
+services:
+  hom-bot:
+    container_name: hom-bot
+    build:
+      context: .
+      dockerfile: dockerfile.dev
+    env_file:
+      - ./.env
+    volumes:
+      - ./hom:/wise-old-man/hom-bot/hom
+      - hom-bot-venv:/wise-old-man/hom-bot/.venv
+    command: nodemon -e py -w hom -x ".venv/bin/python3 -m hom"
+
+volumes:
+  hom-bot-venv:

--- a/dockerfile.dev
+++ b/dockerfile.dev
@@ -1,0 +1,22 @@
+FROM node:18-bullseye-slim as node
+
+# Get nodemon from a prebuilt node image
+RUN npm i -g nodemon
+
+FROM python:3.11.7-slim-bullseye
+WORKDIR /wise-old-man/hom-bot
+
+# Only install node as npm takes forever
+RUN apt-get update && apt-get install -y nodejs
+
+# Project files
+COPY hom ./hom
+COPY requirements.txt .
+
+# Grab nodemon and make it usable in this image
+COPY --from=node /usr/local/lib/node_modules/nodemon /usr/local/lib/node_modules/nodemon
+RUN ln -s /usr/local/lib/node_modules/nodemon/bin/nodemon.js /usr/local/bin/nodemon
+
+# Install dependencies
+RUN python3 -m venv .venv
+RUN .venv/bin/pip3 install -r requirements.txt

--- a/dockerfile.prod
+++ b/dockerfile.prod
@@ -1,0 +1,13 @@
+FROM python:3.11.7-slim-bullseye
+WORKDIR /wise-old-man/hom-bot
+
+# Project files
+COPY hom .
+COPY requirements.txt .
+
+# Install dependencies
+RUN python3 -m venv .venv
+RUN .venv/bin/pip3 install -r requirements.txt
+
+# Run the bot
+RUN .venv/bin/python3 -m hom

--- a/hom/config.py
+++ b/hom/config.py
@@ -16,12 +16,12 @@ def _int(var: str) -> int:
 class Config:
     __slots__ = ()
 
-    DISCORD_TOKEN: t.Final[str] = environ["DISCORD_TOKEN"]
-    SUPPORT_CHANNEL: t.Final[int] = _int("SUPPORT_CHANNEL")
-    TICKET_CATEGORY: t.Final[int] = _int("TICKET_CATEGORY")
-    MOD_LOG_CHANNEL: t.Final[int] = _int("MOD_LOG_CHANNEL")
-    QUESTIONS_CHANNEL: t.Final[int] = _int("QUESTIONS_CHANNEL")
-    MOD_ROLE: t.Final[int] = _int("MOD_ROLE")
+    DISCORD_TOKEN: t.Final[str] = environ["HOM_DISCORD_TOKEN"]
+    SUPPORT_CHANNEL: t.Final[int] = _int("HOM_SUPPORT_CHANNEL")
+    TICKET_CATEGORY: t.Final[int] = _int("HOM_TICKET_CATEGORY")
+    MOD_LOG_CHANNEL: t.Final[int] = _int("HOM_MOD_LOG_CHANNEL")
+    QUESTIONS_CHANNEL: t.Final[int] = _int("HOM_QUESTIONS_CHANNEL")
+    MOD_ROLE: t.Final[int] = _int("HOM_MOD_ROLE")
 
     def __init__(self) -> None:
         raise RuntimeError("Config should not be instantiated.")


### PR DESCRIPTION
This PR adds support for running the bot inside docker.

### Note

This PR should be merged after wise-old-man/nginx-deploy-config#38

### Todo

- Create `wiseoldman/hom` docker hub repo
- Create HOM discord bot app
  - With all intents
  - Save the token
  - Give it a profile picture
- Add the following secrets to the HOM github repo
  - ORG_DOCKER_USERNAME
  - ORG_DOCKER_PASSWORD
  - DO_HOST
  - DO_USER
  - DO_SSH_PASS
  - DO_SSH_KEY
- Merge wise-old-man/nginx-deploy-config#38
- Check perms for old bot, then kick it
- Invite the new bot to the discord server, give necessary perms
- Set correct values in .env on prod server
- Merge this PR
- Delete the existing support embed
- Use `/send` to send the new support embed
- Use `!sync` to sync application commands
