### PR TITLE
Update group verify embed

### DIFF
--- a/hom/utils.py
+++ b/hom/utils.py
@@ -191,11 +191,12 @@ def build_support_embed(guild: discord.Guild) -> discord.Embed:
         )
 
     button_synopsis = (
-        f"\n\n**Groups** {Constants.ARROW} Assistance on group related things\n- Verify my group\n"
-        "- Reset my verification code\n- Remove me from a group\n- Other\n\n**Name Changes** "
-        f"{Constants.ARROW} Help with name related things\n- Approve a pending name change\n- "
-        f"Delete name change history\n- Other\n\n**API Key** {Constants.ARROW} Request an API key "
-        f"for development\n\n**Other** {Constants.ARROW} Request assistance for all other inquiries"
+        f"\n\n**Groups** {Constants.ARROW} Assistance on group related things\n- Verify my group "
+        "(for groups with 50+ members)\n- Reset my verification code\n- Remove me from a group\n"
+        f"- Other\n\n**Name Changes** {Constants.ARROW} Help with name related things\n- Approve a"
+        "pending name change\n- Delete name change history\n- Other\n\n**API Key** "
+        f"{Constants.ARROW} Request an API key for development\n\n**Other** "
+        f"{Constants.ARROW} Request assistance for all other inquiries"
     )
 
     footer = (


### PR DESCRIPTION
This PR adds a qualifier to the support embed for `Groups -> Verify my group` indicating at least 50 members are needed to become a verified group.

Once this PR is merged and the bot is redeployed the `/support send` command will need to be called and the previous support embed deleted.