### PR TITLE
Add group/competition support flows and WomClient integration

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -13,6 +13,9 @@ HOM_TICKET_CATEGORY=789
 # The ID of the moderator role
 HOM_MOD_ROLE=101
 
+# The ID of the group leaders role
+HOM_GROUP_LEADER_ROLE=505
+
 # The ID of the channel to send ticket logs to
 HOM_MOD_LOG_CHANNEL=202
 
@@ -27,3 +30,9 @@ SHARED_ADMIN_PASSWORD=example123
 
 # Base URL for the API to assist with local dev, https://api.wiseoldman.net/v2 for production
 DISCORD_BOT_BASE_API_URL=http://localhost:5000
+
+# Base URL for the API to assist with local dev, https://api.wiseoldman.net/ for production
+DISCORD_BOT_BASE_WEBSITE_URL=http://localhost:3000
+
+# Master key for HOM so we don't hit rate limits
+HOM_API_KEY=abc123

--- a/.example.env
+++ b/.example.env
@@ -31,7 +31,7 @@ SHARED_ADMIN_PASSWORD=example123
 # Base URL for the API to assist with local dev, https://api.wiseoldman.net/v2 for production
 DISCORD_BOT_BASE_API_URL=http://localhost:5000
 
-# Base URL for the API to assist with local dev, https://api.wiseoldman.net/ for production
+# Base URL for the website to assist with local dev, https://wiseoldman.net for production
 DISCORD_BOT_BASE_WEBSITE_URL=http://localhost:3000
 
 # Master key for HOM so we don't hit rate limits

--- a/.example.env
+++ b/.example.env
@@ -34,5 +34,6 @@ DISCORD_BOT_BASE_API_URL=http://localhost:5000
 # Base URL for the website to assist with local dev, https://wiseoldman.net for production
 DISCORD_BOT_BASE_WEBSITE_URL=http://localhost:3000
 
-# Master key for HOM so we don't hit rate limits
-HOM_API_KEY=abc123
+# Master key for HOM so we don't hit rate limits, placeholder API key here 
+# will break things. Either generate the API key or leave blank if developing
+HOM_API_KEY=

--- a/.example.env
+++ b/.example.env
@@ -25,15 +25,15 @@ HOM_QUESTIONS_CHANNEL=303
 # The channel where patreon benefits can be claimed
 HOM_PATREON_CHANNEL=699
 
-# Admin password for mod related API requests
-SHARED_ADMIN_PASSWORD=example123
-
 # Base URL for the API to assist with local dev, https://api.wiseoldman.net/v2 for production
-DISCORD_BOT_BASE_API_URL=http://localhost:5000
+HOM_DISCORD_BOT_BASE_API_URL=http://localhost:5000
 
 # Base URL for the website to assist with local dev, https://wiseoldman.net for production
-DISCORD_BOT_BASE_WEBSITE_URL=http://localhost:3000
+HOM_DISCORD_BOT_BASE_WEBSITE_URL=http://localhost:3000
 
 # Master key for HOM so we don't hit rate limits, placeholder API key here 
 # will break things. Either generate the API key or leave blank if developing
 HOM_API_KEY=
+
+# Admin password for mod related API requests
+SHARED_ADMIN_PASSWORD=example123

--- a/README.md
+++ b/README.md
@@ -49,8 +49,12 @@ compatibility with your linter.
 Still make sure to copy the `.env` file and that your discord bot application
 has proper perms in the developer dashboard.
 
+If `DISCORD_BOT_BASE_API_URL` is set to `http://localhost:5000`, the bot will
+automatically use `host.docker.internal` when it is running inside Docker so it
+can still reach an API running on your host machine.
+
 ```sh
-$ docker-compose up
+$ docker compose up
 ```
 
 Every time you save a python file in the `hom` directory, the bot will restart.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   hom-bot:
     container_name: hom-bot

--- a/dockerfile.dev
+++ b/dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:18-bullseye-slim as node
+FROM node:18-bullseye-slim AS node
 
 # Get nodemon from a prebuilt node image
 RUN npm i -g nodemon
@@ -6,8 +6,9 @@ RUN npm i -g nodemon
 FROM python:3.11.7-slim-bullseye
 WORKDIR /wise-old-man/hom-bot
 
-# Only install node as npm takes forever
-RUN apt-get update && apt-get install -y nodejs
+# Reuse the same Node runtime that nodemon was installed with so its
+# dependencies are compatible with the interpreter in this image.
+COPY --from=node /usr/local/bin/node /usr/local/bin/node
 
 # Project files
 COPY hom ./hom

--- a/hom/__main__.py
+++ b/hom/__main__.py
@@ -5,7 +5,7 @@ from hom.config import Config
 
 if __name__ == "__main__":
     if os.name != "nt":
-        import uvloop
+        import uvloop  # type: ignore[import]
 
         # Faster drop in replacement for the asyncio event loop
         # Only works on unix-like systems

--- a/hom/__main__.py
+++ b/hom/__main__.py
@@ -1,3 +1,4 @@
+import importlib
 import os
 
 from hom.bot import Bot
@@ -5,10 +6,9 @@ from hom.config import Config
 
 if __name__ == "__main__":
     if os.name != "nt":
-        import uvloop  # type: ignore[import]
-
         # Faster drop in replacement for the asyncio event loop
         # Only works on unix-like systems
+        uvloop = importlib.import_module("uvloop")
         uvloop.install()
 
     bot = Bot()

--- a/hom/bot.py
+++ b/hom/bot.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 
+import aiohttp
 import discord
 from discord.ext import commands
-import aiohttp
 
 from hom.config import Constants
 from hom.wom import WomClient
@@ -20,7 +20,6 @@ class Bot(commands.Bot):
         self.wom = WomClient(session)
         for path in Path("./hom/cogs").glob("[!_]*.py"):
             await self.load_extension(f"hom.cogs.{path.stem}")
-
 
     async def on_ready(self) -> None:
         user = self.user.display_name if self.user else "Bot"

--- a/hom/bot.py
+++ b/hom/bot.py
@@ -2,8 +2,10 @@ from pathlib import Path
 
 import discord
 from discord.ext import commands
+import aiohttp
 
 from hom.config import Constants
+from hom.wom import WomClient
 
 __all__ = ("Bot",)
 
@@ -11,10 +13,14 @@ __all__ = ("Bot",)
 class Bot(commands.Bot):
     def __init__(self) -> None:
         super().__init__(Constants.PREFIX, intents=discord.Intents.all())
+        self.wom: WomClient
 
     async def setup_hook(self) -> None:
+        session = aiohttp.ClientSession()
+        self.wom = WomClient(session)
         for path in Path("./hom/cogs").glob("[!_]*.py"):
             await self.load_extension(f"hom.cogs.{path.stem}")
+
 
     async def on_ready(self) -> None:
         user = self.user.display_name if self.user else "Bot"

--- a/hom/cogs/competition.py
+++ b/hom/cogs/competition.py
@@ -1,0 +1,262 @@
+from typing import List, Optional
+
+import discord
+import requests
+from discord import app_commands
+from discord.ext import commands
+
+from hom import utils
+from hom.bot import Bot
+from hom.config import Config, Constants
+
+__all__ = ("Competition",)
+
+
+class Competition(commands.GroupCog, name="competition"):
+    def __init__(self, bot: Bot) -> None:
+        super().__init__()
+        self.bot = bot
+
+    async def competition_autocomplete(
+        self,
+        interaction: discord.Interaction,
+        current: str,
+    ) -> List[app_commands.Choice[int]]:
+        username = getattr(interaction.namespace, "username", None)
+
+        if not username:
+            return []
+
+        url = f"{Config.DISCORD_BOT_BASE_API_URL}/players/{username}/competitions"
+
+        response = requests.get(
+            url = url,
+            headers=Constants.HEADERS,
+        )
+
+        if response.status_code != 200:
+            return []
+
+        data = response.json()
+        search = current.lower().strip()
+        choices: List[app_commands.Choice[int]] = []
+
+        for competition in data:
+            comp_id = competition.get("competitionId")
+            comp_name = competition.get("competition", {}).get("title")
+
+            if comp_id is None:
+                continue
+
+            comp_id_str = str(comp_id)
+
+            if (
+                not search
+                or search in comp_id_str.lower()
+            ):
+                label = f"{comp_id} - {comp_name}"
+
+                # Discord choice names have a max length of 100 chars
+                if len(label) > 100:
+                    label = label[:97] + "..."
+
+                choices.append(
+                    app_commands.Choice(name=label, value=int(comp_id))
+                )
+
+        return choices[:25]
+
+    async def group_autocomplete(
+        self,
+        interaction: discord.Interaction,
+        current: str,
+    ) -> List[app_commands.Choice[int]]:
+        username = getattr(interaction.namespace, "username", None)
+
+        if not username:
+            return []
+
+        url = f"{Config.DISCORD_BOT_BASE_API_URL}/players/{username}/groups"
+
+        response = requests.get(
+            url=url,
+            headers=Constants.HEADERS,
+        )
+
+        if response.status_code != 200:
+            return []
+
+        data = response.json()
+        search = current.lower().strip()
+        choices: List[app_commands.Choice[int]] = []
+
+        seen = set()
+
+        for entry in data:
+            group_id = entry.get("groupId")
+            group_name = entry.get("group", {}).get("name", "")
+
+            if group_id is None or group_id in seen:
+                continue
+
+            seen.add(group_id)
+
+            if group_id is None:
+                continue
+
+            group_id_str = str(group_id)
+
+            if (
+                not search
+                or search in group_id_str.lower()
+                or search in group_name.lower()
+            ):
+                label = f"{group_id} - {group_name}"
+
+                if len(label) > 100:
+                    label = label[:97] + "..."
+
+                choices.append(
+                    app_commands.Choice(name=label, value=int(group_id))
+                )
+
+        return choices[:25]
+
+    @app_commands.guild_only()
+    @app_commands.describe(
+        username="The username of the player you are removing from competitions.",
+        group_id="The group id being used for removal of all group competitions.",
+        competition_id="The competition to remove the player from.",
+        requester="Requester's Discord user tag.",
+    )
+    @app_commands.autocomplete(
+        competition_id=competition_autocomplete,
+        group_id=group_autocomplete,
+    )
+    @app_commands.command(
+        name="remove_from_competitions",
+        description="[Mod :lock:]: Remove a player from group competitions.",
+    )
+    async def remove_from_competitions(
+        self,
+        interaction: discord.Interaction[commands.Bot],
+        username: str,
+        group_id: Optional[int] = None,
+        competition_id: Optional[int] = None,
+        requester: Optional[discord.Member] = None,
+    ) -> None:
+        await interaction.response.defer()
+        assert interaction.guild
+
+        if not await utils.mod_check(interaction):
+            return
+
+        if group_id is not None and competition_id is not None:
+            await interaction.followup.send(
+                "Please enter only a group_id or a competition_id, not both.",
+                ephemeral=True,
+            )
+            return
+
+        if group_id is None and competition_id is None:
+            await interaction.followup.send(
+                "Please enter a Group ID or a Competition ID.",
+                ephemeral=True,
+            )
+            return
+
+
+        url = f"{Config.DISCORD_BOT_BASE_API_URL}/players/{username}/competitions"
+        response = requests.get(
+            url=url,
+            headers=Constants.HEADERS,
+        )
+
+        if response.status_code != 200:
+            await interaction.followup.send(
+                f"Could not find any competitions related to the username: `{username}`."
+            )
+            return
+
+        successful_competitions: List[str] = []
+        error_competitions: List[str] = []
+        skipped_competitions: List[str] = []
+        for comp in response.json():
+            comp_id = comp["competitionId"]
+            competition_link = (
+                f"[{comp_id}]({Config.DISCORD_BOT_BASE_WEBSITE_URL}/competitions/{comp_id})"
+            )
+
+            if group_id == comp["competition"]["groupId"]:
+                response = requests.delete(
+                    url=f"{Config.DISCORD_BOT_BASE_API_URL}/competitions/{comp_id}/participants",
+                    json={
+                        "participants": [username],
+                        "adminPassword": Config.SHARED_ADMIN_PASSWORD,
+                    },
+                )
+
+                if response.status_code != 200:
+                    if "cannot remove all competition participants" in response.text.lower():
+                        skipped_competitions.append(competition_link)
+                    else:
+                        error_competitions.append(
+                            competition_link + f" {Constants.ARROW} ```{response.text}```"
+                        )
+                    continue
+
+                successful_competitions.append(competition_link)
+
+        success_message = (
+            f"Successfully removed `{username}` from the following competitions: "
+            + ", ".join(successful_competitions)[:1900]
+        )
+        error_message = (
+            f"Could not remove `{username}` from the following competitions: "
+            + "\n, ".join(error_competitions)[:1900]
+        )
+        skipped_message = (
+            f"Skipped the following competitions (removing `{username}` would leave them empty): "
+            + ", ".join(skipped_competitions)[:1900]
+        )
+
+        channel_to_send = interaction.channel
+
+        if isinstance(
+            channel_to_send,
+            (
+                discord.TextChannel,
+                discord.VoiceChannel,
+                discord.StageChannel,
+                discord.Thread,
+                discord.DMChannel,
+                discord.GroupChannel,
+            ),
+        ):
+            if successful_competitions:
+                await channel_to_send.send(success_message)
+            if error_competitions:
+                await channel_to_send.send(error_message)
+            if skipped_competitions:
+                await channel_to_send.send(skipped_message)
+
+        await interaction.followup.send(
+            f"{Constants.COMPLETE} Processed request.",
+        )
+
+        requested_by = (
+            f"\nRequested by: {requester.mention}, `{requester.id}`, `{requester.name}`"
+            if requester
+            else ""
+        )
+        await utils.send_log_message(
+            interaction,
+            f"Username: `{username}`\nSuccess Count: `{len(successful_competitions)}`\nSkipped Count: `{len(skipped_competitions)}`\nError Count: `{len(error_competitions)}`{requested_by}",
+            title="Removed User From Group Competitions",
+            mod=interaction.user,
+        )
+
+
+async def setup(bot: Bot) -> None:
+    await bot.add_cog(Competition(bot))
+

--- a/hom/cogs/competition.py
+++ b/hom/cogs/competition.py
@@ -135,7 +135,7 @@ class Competition(commands.GroupCog, name="competition"):
     )
     @app_commands.command(
         name="remove_from_competitions",
-        description="[Mod :lock:]: Remove a player from group competitions.",
+        description="[Mod 🔒]: Remove a player from group competition.",
     )
     async def remove_from_competitions(
         self,
@@ -166,83 +166,107 @@ class Competition(commands.GroupCog, name="competition"):
             return
 
 
-        url = f"{Config.DISCORD_BOT_BASE_API_URL}/players/{username}/competitions"
-        response = requests.get(
-            url=url,
-            headers=Constants.HEADERS,
-        )
-
-        if response.status_code != 200:
-            await interaction.followup.send(
-                f"Could not find any competitions related to the username: `{username}`."
-            )
-            return
-
         successful_competitions: List[str] = []
         error_competitions: List[str] = []
         skipped_competitions: List[str] = []
-        for comp in response.json():
-            comp_id = comp["competitionId"]
+
+        if competition_id is not None:
             competition_link = (
-                f"[{comp_id}]({Config.DISCORD_BOT_BASE_WEBSITE_URL}/competitions/{comp_id})"
+                f"[{competition_id}]({Config.DISCORD_BOT_BASE_WEBSITE_URL}/competitions/{competition_id})"
+            )
+            response = requests.delete(
+                url=f"{Config.DISCORD_BOT_BASE_API_URL}/competitions/{competition_id}/participants",
+                json={
+                    "participants": [username],
+                    "adminPassword": Config.SHARED_ADMIN_PASSWORD,
+                },
             )
 
-            if group_id == comp["competition"]["groupId"]:
-                response = requests.delete(
-                    url=f"{Config.DISCORD_BOT_BASE_API_URL}/competitions/{comp_id}/participants",
-                    json={
-                        "participants": [username],
-                        "adminPassword": Config.SHARED_ADMIN_PASSWORD,
-                    },
+            if response.status_code != 200:
+                if "cannot remove all competition participants" in response.text.lower():
+                    skipped_competitions.append(competition_link)
+                elif "none of the players given were competing" in response.text.lower():
+                    skipped_competitions.append(competition_link + " (Player not found)")
+                else:
+                    error_competitions.append(
+                        competition_link + f" {Constants.ARROW} ```{response.text}```"
+                    )
+            else:
+                successful_competitions.append(competition_link)
+        else:
+            url = f"{Config.DISCORD_BOT_BASE_API_URL}/players/{username}/competitions"
+            response = requests.get(
+                url=url,
+                headers=Constants.HEADERS,
+            )
+
+            if response.status_code != 200:
+                await interaction.followup.send(
+                    f"Could not find any competitions related to the username: `{username}`."
+                )
+                return
+
+            for comp in response.json():
+                comp_id = comp["competitionId"]
+                competition_link = (
+                    f"[{comp_id}]({Config.DISCORD_BOT_BASE_WEBSITE_URL}/competitions/{comp_id})"
                 )
 
-                if response.status_code != 200:
-                    if "cannot remove all competition participants" in response.text.lower():
-                        skipped_competitions.append(competition_link)
-                    else:
-                        error_competitions.append(
-                            competition_link + f" {Constants.ARROW} ```{response.text}```"
-                        )
-                    continue
+                if group_id == comp["competition"]["groupId"]:
+                    response = requests.delete(
+                        url=f"{Config.DISCORD_BOT_BASE_API_URL}/competitions/{comp_id}/participants",
+                        json={
+                            "participants": [username],
+                            "adminPassword": Config.SHARED_ADMIN_PASSWORD,
+                        },
+                    )
 
-                successful_competitions.append(competition_link)
+                    if response.status_code != 200:
+                        if "cannot remove all competition participants" in response.text.lower():
+                            skipped_competitions.append(competition_link)
+                        elif "none of the players given were competing" in response.text.lower():
+                            skipped_competitions.append(competition_link + " (Player not found)")
+                        else:
+                            error_competitions.append(
+                                competition_link + f" {Constants.ARROW} ```{response.text}```"
+                            )
+                        continue
 
-        success_message = (
-            f"Successfully removed `{username}` from the following competitions: "
-            + ", ".join(successful_competitions)[:1900]
+                    successful_competitions.append(competition_link)
+
+        if not any([successful_competitions, error_competitions, skipped_competitions]):
+            await interaction.followup.send(
+                f"No competitions were found for `{username}` under that group."
+            )
+            return
+
+        embed = discord.Embed(
+            title=f"Competition Removal: `{username}`",
+            color=Constants.BLUE,
         )
-        error_message = (
-            f"Could not remove `{username}` from the following competitions: "
-            + "\n, ".join(error_competitions)[:1900]
-        )
-        skipped_message = (
-            f"Skipped the following competitions (removing `{username}` would leave them empty): "
-            + ", ".join(skipped_competitions)[:1900]
-        )
 
-        channel_to_send = interaction.channel
+        if successful_competitions:
+            embed.add_field(
+                name=f"{Constants.COMPLETE} Removed",
+                value=", ".join(successful_competitions)[:1024],
+                inline=False,
+            )
 
-        if isinstance(
-            channel_to_send,
-            (
-                discord.TextChannel,
-                discord.VoiceChannel,
-                discord.StageChannel,
-                discord.Thread,
-                discord.DMChannel,
-                discord.GroupChannel,
-            ),
-        ):
-            if successful_competitions:
-                await channel_to_send.send(success_message)
-            if error_competitions:
-                await channel_to_send.send(error_message)
-            if skipped_competitions:
-                await channel_to_send.send(skipped_message)
+        if error_competitions:
+            embed.add_field(
+                name=f"{Constants.DENIED} Errors",
+                value="\n".join(error_competitions)[:1024],
+                inline=False,
+            )
 
-        await interaction.followup.send(
-            f"{Constants.COMPLETE} Processed request.",
-        )
+        if skipped_competitions:
+            embed.add_field(
+                name="Skipped",
+                value=", ".join(skipped_competitions)[:1024],
+                inline=False,
+            )
+
+        await interaction.followup.send(embed=embed)
 
         requested_by = (
             f"\nRequested by: {requester.mention}, `{requester.id}`, `{requester.name}`"

--- a/hom/cogs/competition.py
+++ b/hom/cogs/competition.py
@@ -1,6 +1,7 @@
 from typing import Any
 from typing import List
 from typing import Optional
+from typing import Set
 
 import discord
 import requests
@@ -85,7 +86,7 @@ class Competition(commands.GroupCog, name="competition"):
         search = current.lower().strip()
         choices: List[app_commands.Choice[int]] = []
 
-        seen: set[int] = set()
+        seen: Set[int] = set()
 
         for entry in data:
             group_id = entry.get("groupId")

--- a/hom/cogs/competition.py
+++ b/hom/cogs/competition.py
@@ -1,4 +1,6 @@
-from typing import List, Optional
+from typing import Any
+from typing import List
+from typing import Optional
 
 import discord
 import requests
@@ -7,7 +9,8 @@ from discord.ext import commands
 
 from hom import utils
 from hom.bot import Bot
-from hom.config import Config, Constants
+from hom.config import Config
+from hom.config import Constants
 
 __all__ = ("Competition",)
 
@@ -19,7 +22,7 @@ class Competition(commands.GroupCog, name="competition"):
 
     async def competition_autocomplete(
         self,
-        interaction: discord.Interaction,
+        interaction: discord.Interaction[Any],
         current: str,
     ) -> List[app_commands.Choice[int]]:
         username = getattr(interaction.namespace, "username", None)
@@ -29,10 +32,7 @@ class Competition(commands.GroupCog, name="competition"):
 
         url = f"{Config.DISCORD_BOT_BASE_API_URL}/players/{username}/competitions"
 
-        response = requests.get(
-            url=url,
-            headers=Constants.HEADERS
-        )
+        response = requests.get(url=url, headers=Constants.HEADERS)
 
         if response.status_code != 200:
             return []
@@ -45,30 +45,25 @@ class Competition(commands.GroupCog, name="competition"):
             comp_id = competition.get("competitionId")
             comp_name = competition.get("competition", {}).get("title")
 
-            if comp_id is None:
+            if not isinstance(comp_id, int):
                 continue
 
             comp_id_str = str(comp_id)
 
-            if (
-                not search
-                or search in comp_id_str.lower()
-            ):
+            if not search or search in comp_id_str.lower():
                 label = f"{comp_id} - {comp_name}"
 
                 # Discord choice names have a max length of 100 chars
                 if len(label) > 100:
                     label = label[:97] + "..."
 
-                choices.append(
-                    app_commands.Choice(name=label, value=int(comp_id))
-                )
+                choices.append(app_commands.Choice(name=label, value=int(comp_id)))
 
         return choices[:25]
 
     async def group_autocomplete(
         self,
-        interaction: discord.Interaction,
+        interaction: discord.Interaction[Any],
         current: str,
     ) -> List[app_commands.Choice[int]]:
         username = getattr(interaction.namespace, "username", None)
@@ -90,39 +85,30 @@ class Competition(commands.GroupCog, name="competition"):
         search = current.lower().strip()
         choices: List[app_commands.Choice[int]] = []
 
-        seen = set()
+        seen: set[int] = set()
 
         for entry in data:
             group_id = entry.get("groupId")
             group_name = entry.get("group", {}).get("name", "")
 
-            if group_id is None or group_id in seen:
+            if not isinstance(group_id, int) or group_id in seen:
                 continue
 
             seen.add(group_id)
 
-            if group_id is None:
-                continue
-
             group_id_str = str(group_id)
 
-            if (
-                not search
-                or search in group_id_str.lower()
-                or search in group_name.lower()
-            ):
+            if not search or search in group_id_str.lower() or search in group_name.lower():
                 label = f"{group_id} - {group_name}"
 
                 if len(label) > 100:
                     label = label[:97] + "..."
 
-                choices.append(
-                    app_commands.Choice(name=label, value=int(group_id))
-                )
+                choices.append(app_commands.Choice(name=label, value=int(group_id)))
 
         return choices[:25]
 
-    @app_commands.guild_only()
+    @app_commands.guild_only()  # type: ignore[arg-type]
     @app_commands.describe(
         username="The username of the player you are removing from competitions.",
         group_id="The group id being used for removal of all group competitions.",
@@ -165,15 +151,12 @@ class Competition(commands.GroupCog, name="competition"):
             )
             return
 
-
         successful_competitions: List[str] = []
         error_competitions: List[str] = []
         skipped_competitions: List[str] = []
 
         if competition_id is not None:
-            competition_link = (
-                f"[{competition_id}]({Config.DISCORD_BOT_BASE_WEBSITE_URL}/competitions/{competition_id})"
-            )
+            competition_link = f"[{competition_id}]({Config.DISCORD_BOT_BASE_WEBSITE_URL}/competitions/{competition_id})"
             response = requests.delete(
                 url=f"{Config.DISCORD_BOT_BASE_API_URL}/competitions/{competition_id}/participants",
                 json={
@@ -285,4 +268,3 @@ class Competition(commands.GroupCog, name="competition"):
 
 async def setup(bot: Bot) -> None:
     await bot.add_cog(Competition(bot))
-

--- a/hom/cogs/competition.py
+++ b/hom/cogs/competition.py
@@ -30,8 +30,8 @@ class Competition(commands.GroupCog, name="competition"):
         url = f"{Config.DISCORD_BOT_BASE_API_URL}/players/{username}/competitions"
 
         response = requests.get(
-            url = url,
-            headers=Constants.HEADERS,
+            url=url,
+            headers=Constants.HEADERS
         )
 
         if response.status_code != 200:
@@ -180,6 +180,7 @@ class Competition(commands.GroupCog, name="competition"):
                     "participants": [username],
                     "adminPassword": Config.SHARED_ADMIN_PASSWORD,
                 },
+                headers=Constants.HEADERS,
             )
 
             if response.status_code != 200:
@@ -219,6 +220,7 @@ class Competition(commands.GroupCog, name="competition"):
                             "participants": [username],
                             "adminPassword": Config.SHARED_ADMIN_PASSWORD,
                         },
+                        headers=Constants.HEADERS,
                     )
 
                     if response.status_code != 200:

--- a/hom/cogs/group.py
+++ b/hom/cogs/group.py
@@ -1,0 +1,268 @@
+import discord
+from discord.ext import commands
+
+from hom import utils, config
+from hom.bot import Bot
+from hom.config import Config, Constants
+from hom.utils import ViewT
+
+class GroupIdModal(discord.ui.Modal, title="Group Lookup"):
+    group_id = discord.ui.TextInput(
+        label="Group ID",
+        placeholder="Enter a group ID...",
+        min_length=1,
+        max_length=6,
+    )
+
+    async def on_submit(self, interaction: discord.Interaction[commands.Bot]) -> None:
+        await interaction.response.defer(ephemeral=True)
+
+        data = await interaction.client.wom.get_group(self.group_id)
+        if data is None:
+            embed = discord.Embed(
+                title=f"Group Lookup Failed",
+                colour=discord.Colour.red(),
+                url=f"{Config.DISCORD_BOT_BASE_WEBSITE_URL}/groups/{self.group_id.value}"
+            )
+            embed.add_field(name="Not Found", value=f"This group ({self.group_id.value}) does not exist.", inline=False)
+            await interaction.followup.send(embed=embed)
+            return
+
+
+
+        embed = discord.Embed(
+            title=f"Group Lookup",
+            colour=discord.Colour.blue(),
+            url=f"{Config.DISCORD_BOT_BASE_WEBSITE_URL}/groups/{self.group_id.value}"
+        )
+        embed.add_field(name="ID", value=data["id"])
+        embed.add_field(name="Name", value=data["name"])
+        embed.add_field(name="Total Members", value=data["memberCount"])
+        leaders = [data["player"]["displayName"] for data in data["memberships"] if data["role"] in ("owner", "deputy_owner")]
+
+        embed.add_field(name="Leaders", value="\n ".join(leaders), inline=False)
+        og_user = await utils.get_user_by_original_message(interaction.channel)
+        embed.add_field(name="Requested By", value=og_user.mention)
+        embed.add_field(name="Requested By ID", value=og_user.id, inline=True)
+        embed.add_field(name="Requested By Name", value=og_user.name, inline=True)
+
+
+        await interaction.followup.send(embed=embed, view=ApproveDenyGroupRequest(self.group_id.value))
+
+
+class PlayerGroupModal(discord.ui.Modal, title="Player Lookup"):
+    rsn = discord.ui.TextInput(
+        label="Runescape Name",
+        placeholder="Enter a username...",
+        default="PhyrWall",
+        min_length=1,
+        max_length=12,
+    )
+    group_id = discord.ui.TextInput(
+        label="Group ID (listed on group's page)",
+        placeholder="ex. 123",
+        default="1",
+        min_length=1,
+        max_length=6,
+    )
+
+    async def on_submit(self, interaction: discord.Interaction[commands.Bot]) -> None:
+        await interaction.response.defer(ephemeral=True)
+
+        data = await interaction.client.wom.get_group(self.group_id)
+        if data is None:
+            embed = discord.Embed(
+                title=f"Group Lookup Failed",
+                colour=discord.Colour.red(),
+                url=f"{Config.DISCORD_BOT_BASE_WEBSITE_URL}/groups/{self.group_id.value}"
+            )
+            embed.add_field(name="Not Found", value=f"This group ({self.group_id.value}) does not exist.", inline=False)
+            await interaction.followup.send(embed=embed)
+            return
+
+        usernames = [m["player"]["username"] for m in data['memberships']]
+        if (self.rsn.value).lower() in str(usernames).lower():
+
+            embed = discord.Embed(
+                title="Player Group Lookup",
+                colour=discord.Colour.green(),
+                url=f"{Config.DISCORD_BOT_BASE_WEBSITE_URL}/players/{self.rsn.value}"
+            )
+            embed.add_field(name="Player", value=self.rsn.value)
+            embed.add_field(name="Group",
+                            value=data['name'])
+            embed.add_field(name="Group ID",
+                            value=f"[{data['id']}]({Config.DISCORD_BOT_BASE_WEBSITE_URL}/groups/{data['id']})")
+
+            embed.set_footer(text="The buttons below are for admin use only.")
+
+            await interaction.followup.send(embed=embed, view=ApproveDenyPlayerRemoveRequest(
+                rsn=self.rsn.value, group_id=self.group_id.value, group_name=data['name']
+            ))
+        else:
+            embed=discord.Embed(
+                title=f"Player Lookup",
+                colour=discord.Colour.red(),
+                url=f"{Config.DISCORD_BOT_BASE_WEBSITE_URL}/players/{self.rsn.value}"
+            )
+            embed.add_field(name=f"{self.rsn.value} not found in group", value=f"{data['name']} ({data['id']})")
+            embed.set_footer(text="Please verify you have typed the correct RSN and Group ID.")
+            await interaction.channel.send(embed=embed)
+
+class ApproveDenyPlayerRemoveRequest(discord.ui.View):
+    def __init__(self, rsn: str, group_id: str, group_name: str) -> None:
+        super().__init__(timeout=None)
+        self.rsn = rsn
+        self.group_id = group_id
+        self.group_name = group_name
+
+    @discord.ui.button(
+        emoji="\N{CLOCKWISE RIGHTWARDS AND LEFTWARDS OPEN CIRCLE ARROWS}",
+        label="Remove Player From Group",
+        style=discord.ButtonStyle.blurple,
+        custom_id="persistent_view:remove_player_from_group",  # must be unique
+    )
+    async def remove_player_from_group(self: "ApproveDenyPlayerRemoveRequest",
+                                       interaction: discord.Interaction[Bot],
+                                       _: discord.ui.Button[ViewT]) -> None:
+        assert isinstance(interaction.user, discord.Member)
+        await interaction.response.defer(ephemeral=True)
+        if not any(role.id == Config.MOD_ROLE for role in interaction.user.roles):
+            await interaction.response.followup(
+                f"{Constants.DENIED} You do not have the required permissions to use this.",
+                ephemeral=True
+            )
+            return
+
+        message = interaction.message
+        group_id = message.embeds[0].fields[2].value
+        rsn = message.embeds[0].fields[0].value
+        print(group_id, rsn)
+
+        removed = await interaction.client.wom.remove_player_group(rsn=rsn, group_id=group_id)
+
+        if removed is None:
+            await interaction.followup.send("Failed to remove player from group.", ephemeral=True)
+            return
+
+        embed = discord.Embed(title="Player Removed from Group")
+        embed.add_field(name="Runescape Name", value=rsn)
+        embed.add_field(name="Group ID", value=group_id)
+        await interaction.followup.send(embed=embed)
+
+class ApproveDenyGroupRequest(discord.ui.View):
+    def __init__(self, group_id: str) -> None:
+        super().__init__(timeout=None)
+        self.group_id = group_id
+        self.user = discord.user
+
+    @discord.ui.button(
+        emoji=f"{Constants.COMPLETE}",
+        label=f"Verify Group",
+        style=discord.ButtonStyle.blurple,
+        custom_id="persistent_view:verify_group",
+    )
+    async def verify_group(
+        self: "ApproveDenyGroupRequest", interaction: discord.Interaction[Bot],
+        _: discord.ui.Button["ApproveDenyGroupRequest"]
+    ) -> None:
+        assert isinstance(interaction.user, discord.Member)
+        ticket_user = await utils.get_user_by_original_message(interaction.channel)
+        assert isinstance(ticket_user, discord.Member)
+
+        await interaction.response.defer(ephemeral=True)
+
+        if not any(role.id == Config.MOD_ROLE for role in interaction.user.roles):
+            await interaction.followup.send(
+                f"{Constants.DENIED} You do not have the required permissions to use this.",
+                ephemeral=True
+            )
+            return
+
+        message = interaction.message
+        group_id = message.embeds[0].fields[0].value if message and message.embeds else None
+
+        if not group_id:
+            await interaction.followup.send(
+                "Could not determine group ID.", ephemeral=True
+            )
+            return
+
+        verified = await interaction.client.wom.verify_group(self.group_id)
+        if not verified:
+            await interaction.followup.send(
+                f"Failed to verify group `{self.group_id}`. Check the ID and try again.",
+                ephemeral=True,
+            )
+            return
+
+        if role := utils.get_role(interaction.guild, Config.GROUP_LEADER_ROLE):
+            await ticket_user.add_roles(role)
+
+        data = await interaction.client.wom.get_group(self.group_id)
+        if data is None:
+            await interaction.followup.send(
+                f"Group `{self.group_id}` verified but could not fetch details.",
+                ephemeral=True,
+            )
+            return
+
+        embed = discord.Embed(title="Group Verified", colour=discord.Colour.green())
+        embed.add_field(name="ID", value=group_id)
+        embed.add_field(name="Group Name", value=data["name"])
+        if role := utils.get_role(interaction.guild, Config.GROUP_LEADER_ROLE):
+            await ticket_user.add_roles(role)
+        await utils.send_log_message(
+            interaction,
+            f"Group: [{group_id}]({Config.DISCORD_BOT_BASE_WEBSITE_URL}/groups/{group_id})\n"
+            f"Verified by: {ticket_user.mention}, `{ticket_user.id}`, `{ticket_user.name}`",
+            title="Verified Group",
+            mod=interaction.user,
+        )
+        await interaction.followup.send(embed=embed)
+
+    @discord.ui.button(
+        emoji="\N{CLOCKWISE RIGHTWARDS AND LEFTWARDS OPEN CIRCLE ARROWS}",
+        label="Reset Group Code",
+        style=discord.ButtonStyle.blurple,
+        custom_id="persistent_view:reset_group_code",  # must be unique
+    )
+    async def reset_group_code(
+        self: ViewT, interaction: discord.Interaction[Bot], _: discord.ui.Button[ViewT]
+    ) -> None:
+        assert isinstance(interaction.user, discord.Member)
+
+        await interaction.response.defer(ephemeral=True)
+
+        if not any(role.id == Config.MOD_ROLE for role in interaction.user.roles):
+            await interaction.followup.send(
+                f"{Constants.DENIED} You do not have the required permissions to use this.",
+                ephemeral=True
+            )
+            return
+
+        message = interaction.message
+        group_id = message.embeds[0].fields[0].value if message and message.embeds else None
+
+        data = await interaction.client.wom.get_group(group_id)
+        if data is None:
+            await interaction.followup.send(f"Could not find group...")
+            return
+        reset_code = await interaction.client.wom.reset_group_code(group_id)
+
+        ticket_user = await utils.get_user_by_original_message(interaction.channel)
+        await ticket_user.send(
+            f"Your verification code for group [{group_id}]({config.Config.DISCORD_BOT_BASE_WEBSITE_URL}/groups/{group_id}) has been reset.\n"
+            f"```{reset_code['newCode']}```"
+            f"Keep this code secret — it can be used to edit or delete your group."
+        )
+        embed = discord.Embed(title="Reset Group Code", colour=discord.Colour.green())
+        embed.add_field(name="Group ID", value=group_id)
+        embed.add_field(name="Group Name", value=data["name"])
+        embed.description = f"Verification code successfully reset. A DM has been sent to {ticket_user.mention}."
+        await interaction.followup.send(embed=embed)
+
+
+async def setup(bot: commands.Bot) -> None:
+    bot.add_view(ApproveDenyGroupRequest(group_id=""))
+    bot.add_view(ApproveDenyPlayerRemoveRequest(rsn="", group_id="", group_name=""))

--- a/hom/cogs/group.py
+++ b/hom/cogs/group.py
@@ -6,6 +6,39 @@ from hom.bot import Bot
 from hom.config import Config, Constants
 from hom.utils import ViewT
 
+
+async def _build_group_lookup_permission_message(
+    interaction: discord.Interaction[Bot],
+) -> str:
+    message = f"{Constants.DENIED} You do not have the required permissions to use this."
+
+    if not isinstance(interaction.channel, discord.TextChannel):
+        return message
+
+    if interaction.client.user is None:
+        return message
+
+    async for channel_message in interaction.channel.history(limit=None):
+        if channel_message.author.id != interaction.client.user.id:
+            continue
+
+        if not channel_message.embeds:
+            continue
+
+        if not any(
+            mentioned_user.id == interaction.user.id
+            for mentioned_user in channel_message.mentions
+        ):
+            continue
+
+        return (
+            f"{message}\n"
+            f"If you haven't already, please follow these instructions: {channel_message.jump_url}"
+        )
+
+    return message
+
+
 class GroupIdModal(discord.ui.Modal, title="Group Lookup"):
     group_id = discord.ui.TextInput(
         label="Group ID",
@@ -44,6 +77,15 @@ class GroupIdModal(discord.ui.Modal, title="Group Lookup"):
         embed.add_field(name="Requested By", value=og_user.mention)
         embed.add_field(name="Requested By ID", value=og_user.id, inline=True)
         embed.add_field(name="Requested By Name", value=og_user.name, inline=True)
+        embed.add_field(
+            name="\u200b",
+            value=(
+                "-# Not your group? You can find your group id on the "
+                f"[website]({Config.DISCORD_BOT_BASE_WEBSITE_URL}/groups) just below the group "
+                "name and description."
+            ),
+            inline=False,
+        )
 
         await interaction.followup.send(embed=embed, view=ApproveDenyGroupRequest(self.group_id.value))
 
@@ -172,7 +214,7 @@ class ApproveDenyGroupRequest(discord.ui.View):
 
         if not any(role.id == Config.MOD_ROLE for role in interaction.user.roles):
             await interaction.followup.send(
-                f"{Constants.DENIED} You do not have the required permissions to use this.",
+                await _build_group_lookup_permission_message(interaction),
                 ephemeral=True
             )
             return
@@ -235,7 +277,7 @@ class ApproveDenyGroupRequest(discord.ui.View):
 
         if not any(role.id == Config.MOD_ROLE for role in interaction.user.roles):
             await interaction.followup.send(
-                f"{Constants.DENIED} You do not have the required permissions to use this.",
+                await _build_group_lookup_permission_message(interaction),
                 ephemeral=True
             )
             return
@@ -260,6 +302,17 @@ class ApproveDenyGroupRequest(discord.ui.View):
         embed.add_field(name="Group Name", value=data["name"])
         embed.description = f"Verification code successfully reset. A DM has been sent to {ticket_user.mention}."
         await interaction.followup.send(embed=embed)
+
+    @discord.ui.button(
+        emoji=Constants.PEN,
+        label="Group Lookup",
+        style=discord.ButtonStyle.blurple,
+        custom_id="persistent_view:approve_deny_group_lookup",
+    )
+    async def group_lookup(
+        self: ViewT, interaction: discord.Interaction[Bot], _: discord.ui.Button[ViewT]
+    ) -> None:
+        await interaction.response.send_modal(GroupIdModal())
 
 
 async def setup(bot: commands.Bot) -> None:

--- a/hom/cogs/group.py
+++ b/hom/cogs/group.py
@@ -355,7 +355,7 @@ class ApproveDenyGroupRequest(discord.ui.View):
         await utils.send_log_message(
             interaction,
             f"Group: [{group_id}]({Config.DISCORD_BOT_BASE_WEBSITE_URL}/groups/{group_id})\n"
-            f"Verified for: {ticket_user.mention}, `{ticket_user.id}`, `{ticket_user.name}`",
+            f"Verified by: {ticket_user.mention}, `{ticket_user.id}`, `{ticket_user.name}`",
             title="Verified Group",
             mod=interaction.user,
         )

--- a/hom/cogs/group.py
+++ b/hom/cogs/group.py
@@ -251,7 +251,7 @@ class ApproveDenyGroupRequest(discord.ui.View):
 
         ticket_user = await utils.get_user_by_original_message(interaction.channel)
         await ticket_user.send(
-            f"Your verification code for group [{group_id}]({config.Config.DISCORD_BOT_BASE_WEBSITE_URL}/groups/{group_id}) has been reset.\n"
+            f"Your verification code for group [{group_id}]({Config.DISCORD_BOT_BASE_WEBSITE_URL}/groups/{group_id}) has been reset.\n"
             f"```{reset_code['newCode']}```"
             f"Keep this code secret — it can be used to edit or delete your group."
         )

--- a/hom/cogs/group.py
+++ b/hom/cogs/group.py
@@ -355,7 +355,7 @@ class ApproveDenyGroupRequest(discord.ui.View):
         await utils.send_log_message(
             interaction,
             f"Group: [{group_id}]({Config.DISCORD_BOT_BASE_WEBSITE_URL}/groups/{group_id})\n"
-            f"Verified by: {ticket_user.mention}, `{ticket_user.id}`, `{ticket_user.name}`",
+            f"Verified for: {ticket_user.mention}, `{ticket_user.id}`, `{ticket_user.name}`",
             title="Verified Group",
             mod=interaction.user,
         )

--- a/hom/cogs/group.py
+++ b/hom/cogs/group.py
@@ -1,10 +1,58 @@
-import discord
-from discord.ext import commands
+import re
+import typing as t
 
-from hom import utils, config
+import discord
+
+from hom import utils
 from hom.bot import Bot
-from hom.config import Config, Constants
+from hom.config import Config
+from hom.config import Constants
 from hom.utils import ViewT
+
+_GROUP_ID_LINK_PATTERN = re.compile(r"\[(?P<group_id>\d+)\]\(")
+
+
+def _get_bot(interaction: discord.Interaction[t.Any]) -> Bot:
+    client = interaction.client
+    if not isinstance(client, Bot):
+        raise RuntimeError("Unexpected interaction client type.")
+
+    return client
+
+
+def _get_embed_field_value(message: t.Optional[discord.Message], index: int) -> t.Optional[str]:
+    if message is None or not message.embeds:
+        return None
+
+    fields = message.embeds[0].fields
+    if len(fields) <= index:
+        return None
+
+    value = fields[index].value
+    return str(value) if value else None
+
+
+def _parse_group_id(value: t.Optional[str]) -> t.Optional[str]:
+    if not value:
+        return None
+
+    if match := _GROUP_ID_LINK_PATTERN.search(value):
+        return match.group("group_id")
+
+    return value
+
+
+async def _get_ticket_channel(
+    interaction: discord.Interaction[t.Any],
+) -> t.Optional[discord.TextChannel]:
+    if isinstance(interaction.channel, discord.TextChannel):
+        return interaction.channel
+
+    await interaction.followup.send(
+        "This action can only be used within a support ticket channel.",
+        ephemeral=True,
+    )
+    return None
 
 
 async def _build_group_lookup_permission_message(
@@ -26,8 +74,7 @@ async def _build_group_lookup_permission_message(
             continue
 
         if not any(
-            mentioned_user.id == interaction.user.id
-            for mentioned_user in channel_message.mentions
+            mentioned_user.id == interaction.user.id for mentioned_user in channel_message.mentions
         ):
             continue
 
@@ -40,43 +87,61 @@ async def _build_group_lookup_permission_message(
 
 
 class GroupIdModal(discord.ui.Modal, title="Group Lookup"):
-    group_id = discord.ui.TextInput(
+    group_id: discord.ui.TextInput["GroupIdModal"] = discord.ui.TextInput(
         label="Group ID",
         placeholder="Enter a group ID...",
         min_length=1,
         max_length=6,
     )
 
-    async def on_submit(self, interaction: discord.Interaction[commands.Bot]) -> None:
+    async def on_submit(self, interaction: discord.Interaction[t.Any]) -> None:
         await interaction.response.defer(ephemeral=True)
 
-        data = await interaction.client.wom.get_group(self.group_id)
+        bot = _get_bot(interaction)
+        group_id = self.group_id.value
+        data = await bot.wom.get_group(group_id)
         if data is None:
             embed = discord.Embed(
-                title=f"Group Lookup Failed",
+                title="Group Lookup Failed",
                 colour=discord.Colour.red(),
-                url=f"{Config.DISCORD_BOT_BASE_WEBSITE_URL}/groups/{self.group_id.value}"
+                url=f"{Config.DISCORD_BOT_BASE_WEBSITE_URL}/groups/{group_id}",
             )
-            embed.add_field(name="Not Found", value=f"This group ({self.group_id.value}) does not exist.", inline=False)
+            embed.add_field(
+                name="Not Found",
+                value=f"This group ({group_id}) does not exist.",
+                inline=False,
+            )
             await interaction.followup.send(embed=embed)
             return
 
-
         embed = discord.Embed(
-            title=f"Group Lookup",
+            title="Group Lookup",
             colour=discord.Colour.blue(),
-            url=f"{Config.DISCORD_BOT_BASE_WEBSITE_URL}/groups/{self.group_id.value}"
+            url=f"{Config.DISCORD_BOT_BASE_WEBSITE_URL}/groups/{group_id}",
         )
-        embed.add_field(name="ID", value=data["id"])
-        embed.add_field(name="Name", value=data["name"])
-        embed.add_field(name="Total Members", value=data["memberCount"])
-        leaders = [data["player"]["displayName"] for data in data["memberships"] if data["role"] in ("owner", "deputy_owner")]
+        embed.add_field(name="ID", value=str(data["id"]))
+        embed.add_field(name="Name", value=str(data["name"]))
+        embed.add_field(name="Total Members", value=str(data["memberCount"]))
+        leaders = [
+            membership["player"]["displayName"]
+            for membership in data["memberships"]
+            if membership["role"] in ("owner", "deputy_owner")
+        ]
 
-        embed.add_field(name="Leaders", value="\n ".join(leaders), inline=False)
-        og_user = await utils.get_user_by_original_message(interaction.channel)
-        embed.add_field(name="Requested By", value=og_user.mention)
-        embed.add_field(name="Requested By ID", value=og_user.id, inline=True)
-        embed.add_field(name="Requested By Name", value=og_user.name, inline=True)
+        embed.add_field(name="Leaders", value="\n".join(leaders), inline=False)
+
+        requested_by = "Unknown"
+        requested_by_id = "Unknown"
+        requested_by_name = "Unknown"
+        if channel := await _get_ticket_channel(interaction):
+            if og_user := await utils.get_user_by_original_message(channel):
+                requested_by = og_user.mention
+                requested_by_id = str(og_user.id)
+                requested_by_name = og_user.name
+
+        embed.add_field(name="Requested By", value=requested_by)
+        embed.add_field(name="Requested By ID", value=requested_by_id, inline=True)
+        embed.add_field(name="Requested By Name", value=requested_by_name, inline=True)
         embed.add_field(
             name="\u200b",
             value=(
@@ -87,18 +152,18 @@ class GroupIdModal(discord.ui.Modal, title="Group Lookup"):
             inline=False,
         )
 
-        await interaction.followup.send(embed=embed, view=ApproveDenyGroupRequest(self.group_id.value))
+        await interaction.followup.send(embed=embed, view=ApproveDenyGroupRequest(group_id))
 
 
 class PlayerGroupModal(discord.ui.Modal, title="Player Lookup"):
-    rsn = discord.ui.TextInput(
+    rsn: discord.ui.TextInput["PlayerGroupModal"] = discord.ui.TextInput(
         label="Runescape Name",
         placeholder="Enter a username...",
         default="",
         min_length=1,
         max_length=12,
     )
-    group_id = discord.ui.TextInput(
+    group_id: discord.ui.TextInput["PlayerGroupModal"] = discord.ui.TextInput(
         label="Group ID (listed on group's page)",
         placeholder="ex. 123",
         default="",
@@ -106,48 +171,67 @@ class PlayerGroupModal(discord.ui.Modal, title="Player Lookup"):
         max_length=6,
     )
 
-    async def on_submit(self, interaction: discord.Interaction[commands.Bot]) -> None:
+    async def on_submit(self, interaction: discord.Interaction[t.Any]) -> None:
         await interaction.response.defer(ephemeral=True)
 
-        data = await interaction.client.wom.get_group(self.group_id)
+        bot = _get_bot(interaction)
+        rsn = self.rsn.value
+        group_id = self.group_id.value
+        data = await bot.wom.get_group(group_id)
         if data is None:
             embed = discord.Embed(
-                title=f"Group Lookup Failed",
+                title="Group Lookup Failed",
                 colour=discord.Colour.red(),
-                url=f"{Config.DISCORD_BOT_BASE_WEBSITE_URL}/groups/{self.group_id.value}"
+                url=f"{Config.DISCORD_BOT_BASE_WEBSITE_URL}/groups/{group_id}",
             )
-            embed.add_field(name="Not Found", value=f"This group ({self.group_id.value}) does not exist.", inline=False)
+            embed.add_field(
+                name="Not Found",
+                value=f"This group ({group_id}) does not exist.",
+                inline=False,
+            )
             await interaction.followup.send(embed=embed)
             return
 
-        usernames = [m["player"]["username"] for m in data['memberships']]
-        if (self.rsn.value).lower() in str(usernames).lower():
-
+        usernames = [membership["player"]["username"] for membership in data["memberships"]]
+        if any(username.lower() == rsn.lower() for username in usernames):
             embed = discord.Embed(
                 title="Player Group Lookup",
                 colour=discord.Colour.green(),
-                url=f"{Config.DISCORD_BOT_BASE_WEBSITE_URL}/players/{self.rsn.value}"
+                url=f"{Config.DISCORD_BOT_BASE_WEBSITE_URL}/players/{rsn}",
             )
-            embed.add_field(name="Player", value=self.rsn.value)
-            embed.add_field(name="Group",
-                            value=data['name'])
-            embed.add_field(name="Group ID",
-                            value=f"[{data['id']}]({Config.DISCORD_BOT_BASE_WEBSITE_URL}/groups/{data['id']})")
-
+            embed.add_field(name="Player", value=rsn)
+            embed.add_field(name="Group", value=str(data["name"]))
+            embed.add_field(
+                name="Group ID",
+                value=(
+                    f"[{data['id']}]"
+                    f"({Config.DISCORD_BOT_BASE_WEBSITE_URL}/groups/{data['id']})"
+                ),
+            )
             embed.set_footer(text="The buttons below are for admin use only.")
 
-            await interaction.followup.send(embed=embed, view=ApproveDenyPlayerRemoveRequest(
-                rsn=self.rsn.value, group_id=self.group_id.value, group_name=data['name']
-            ))
-        else:
-            embed=discord.Embed(
-                title=f"Player Lookup",
-                colour=discord.Colour.red(),
-                url=f"{Config.DISCORD_BOT_BASE_WEBSITE_URL}/players/{self.rsn.value}"
+            await interaction.followup.send(
+                embed=embed,
+                view=ApproveDenyPlayerRemoveRequest(
+                    rsn=rsn,
+                    group_id=group_id,
+                    group_name=str(data["name"]),
+                ),
             )
-            embed.add_field(name=f"{self.rsn.value} not found in group", value=f"{data['name']} ({data['id']})")
-            embed.set_footer(text="Please verify you have typed the correct RSN and Group ID.")
-            await interaction.channel.send(embed=embed)
+            return
+
+        embed = discord.Embed(
+            title="Player Lookup",
+            colour=discord.Colour.red(),
+            url=f"{Config.DISCORD_BOT_BASE_WEBSITE_URL}/players/{rsn}",
+        )
+        embed.add_field(
+            name=f"{rsn} not found in group",
+            value=f"{data['name']} ({data['id']})",
+        )
+        embed.set_footer(text="Please verify you have typed the correct RSN and Group ID.")
+        await interaction.followup.send(embed=embed)
+
 
 class ApproveDenyPlayerRemoveRequest(discord.ui.View):
     def __init__(self, rsn: str, group_id: str, group_name: str) -> None:
@@ -160,78 +244,96 @@ class ApproveDenyPlayerRemoveRequest(discord.ui.View):
         emoji="\N{CLOCKWISE RIGHTWARDS AND LEFTWARDS OPEN CIRCLE ARROWS}",
         label="Remove Player From Group",
         style=discord.ButtonStyle.blurple,
-        custom_id="persistent_view:remove_player_from_group",  # must be unique
+        custom_id="persistent_view:remove_player_from_group",
     )
-    async def remove_player_from_group(self: "ApproveDenyPlayerRemoveRequest",
-                                       interaction: discord.Interaction[Bot],
-                                       _: discord.ui.Button[ViewT]) -> None:
+    async def remove_player_from_group(
+        self: "ApproveDenyPlayerRemoveRequest",
+        interaction: discord.Interaction[Bot],
+        _: discord.ui.Button[ViewT],
+    ) -> None:
         assert isinstance(interaction.user, discord.Member)
         await interaction.response.defer(ephemeral=True)
+
         if not any(role.id == Config.MOD_ROLE for role in interaction.user.roles):
-            await interaction.response.followup(
+            await interaction.followup.send(
                 f"{Constants.DENIED} You do not have the required permissions to use this.",
-                ephemeral=True
+                ephemeral=True,
             )
             return
 
-        message = interaction.message
-        group_id = message.embeds[0].fields[2].value
-        rsn = message.embeds[0].fields[0].value
-        print(group_id, rsn)
+        rsn = self.rsn or _get_embed_field_value(interaction.message, 0)
+        group_id = self.group_id or _parse_group_id(_get_embed_field_value(interaction.message, 2))
+        group_name = self.group_name or _get_embed_field_value(interaction.message, 1) or "Unknown"
+        if rsn is None or group_id is None:
+            await interaction.followup.send(
+                "Could not determine the player or group to update.",
+                ephemeral=True,
+            )
+            return
 
         removed = await interaction.client.wom.remove_player_group(rsn=rsn, group_id=group_id)
-
         if removed is None:
-            await interaction.followup.send("Failed to remove player from group.", ephemeral=True)
+            await interaction.followup.send(
+                "Failed to remove player from group.",
+                ephemeral=True,
+            )
             return
 
         embed = discord.Embed(title="Player Removed from Group")
         embed.add_field(name="Runescape Name", value=rsn)
         embed.add_field(name="Group ID", value=group_id)
+        embed.add_field(name="Group Name", value=group_name)
         await interaction.followup.send(embed=embed)
+
 
 class ApproveDenyGroupRequest(discord.ui.View):
     def __init__(self, group_id: str) -> None:
         super().__init__(timeout=None)
         self.group_id = group_id
-        self.user = discord.user
 
     @discord.ui.button(
-        emoji=f"{Constants.COMPLETE}",
-        label=f"Verify Group",
+        emoji=Constants.COMPLETE,
+        label="Verify Group",
         style=discord.ButtonStyle.blurple,
         custom_id="persistent_view:verify_group",
     )
     async def verify_group(
-        self: "ApproveDenyGroupRequest", interaction: discord.Interaction[Bot],
-        _: discord.ui.Button["ApproveDenyGroupRequest"]
+        self: "ApproveDenyGroupRequest",
+        interaction: discord.Interaction[Bot],
+        _: discord.ui.Button["ApproveDenyGroupRequest"],
     ) -> None:
         assert isinstance(interaction.user, discord.Member)
-        ticket_user = await utils.get_user_by_original_message(interaction.channel)
-        assert isinstance(ticket_user, discord.Member)
-
+        assert interaction.guild is not None
         await interaction.response.defer(ephemeral=True)
 
         if not any(role.id == Config.MOD_ROLE for role in interaction.user.roles):
             await interaction.followup.send(
                 await _build_group_lookup_permission_message(interaction),
-                ephemeral=True
+                ephemeral=True,
             )
             return
 
-        message = interaction.message
-        group_id = message.embeds[0].fields[0].value if message and message.embeds else None
+        channel = await _get_ticket_channel(interaction)
+        if channel is None:
+            return
 
-        if not group_id:
+        ticket_user = await utils.get_user_by_original_message(channel)
+        if not isinstance(ticket_user, discord.Member):
             await interaction.followup.send(
-                "Could not determine group ID.", ephemeral=True
+                "Could not determine the ticket owner.",
+                ephemeral=True,
             )
             return
 
-        verified = await interaction.client.wom.verify_group(self.group_id)
+        group_id = self.group_id or _parse_group_id(_get_embed_field_value(interaction.message, 0))
+        if not group_id:
+            await interaction.followup.send("Could not determine group ID.", ephemeral=True)
+            return
+
+        verified = await interaction.client.wom.verify_group(group_id)
         if not verified:
             await interaction.followup.send(
-                f"Failed to verify group `{self.group_id}`. Check the ID and try again.",
+                f"Failed to verify group `{group_id}`. Check the ID and try again.",
                 ephemeral=True,
             )
             return
@@ -239,19 +341,17 @@ class ApproveDenyGroupRequest(discord.ui.View):
         if role := utils.get_role(interaction.guild, Config.GROUP_LEADER_ROLE):
             await ticket_user.add_roles(role)
 
-        data = await interaction.client.wom.get_group(self.group_id)
+        data = await interaction.client.wom.get_group(group_id)
         if data is None:
             await interaction.followup.send(
-                f"Group `{self.group_id}` verified but could not fetch details.",
+                f"Group `{group_id}` verified but could not fetch details.",
                 ephemeral=True,
             )
             return
 
         embed = discord.Embed(title="Group Verified", colour=discord.Colour.green())
         embed.add_field(name="ID", value=group_id)
-        embed.add_field(name="Group Name", value=data["name"])
-        if role := utils.get_role(interaction.guild, Config.GROUP_LEADER_ROLE):
-            await ticket_user.add_roles(role)
+        embed.add_field(name="Group Name", value=str(data["name"]))
         await utils.send_log_message(
             interaction,
             f"Group: [{group_id}]({Config.DISCORD_BOT_BASE_WEBSITE_URL}/groups/{group_id})\n"
@@ -266,41 +366,67 @@ class ApproveDenyGroupRequest(discord.ui.View):
         emoji="\N{CLOCKWISE RIGHTWARDS AND LEFTWARDS OPEN CIRCLE ARROWS}",
         label="Reset Group Code",
         style=discord.ButtonStyle.blurple,
-        custom_id="persistent_view:reset_group_code",  # must be unique
+        custom_id="persistent_view:reset_group_code",
     )
     async def reset_group_code(
-        self: ViewT, interaction: discord.Interaction[Bot], _: discord.ui.Button[ViewT]
+        self: "ApproveDenyGroupRequest",
+        interaction: discord.Interaction[Bot],
+        _: discord.ui.Button["ApproveDenyGroupRequest"],
     ) -> None:
         assert isinstance(interaction.user, discord.Member)
-
         await interaction.response.defer(ephemeral=True)
 
         if not any(role.id == Config.MOD_ROLE for role in interaction.user.roles):
             await interaction.followup.send(
                 await _build_group_lookup_permission_message(interaction),
-                ephemeral=True
+                ephemeral=True,
             )
             return
 
-        message = interaction.message
-        group_id = message.embeds[0].fields[0].value if message and message.embeds else None
+        group_id = self.group_id or _parse_group_id(_get_embed_field_value(interaction.message, 0))
+        if group_id is None:
+            await interaction.followup.send("Could not determine group ID.", ephemeral=True)
+            return
 
         data = await interaction.client.wom.get_group(group_id)
         if data is None:
-            await interaction.followup.send(f"Could not find group...")
+            await interaction.followup.send("Could not find group...", ephemeral=True)
             return
-        reset_code = await interaction.client.wom.reset_group_code(group_id)
 
-        ticket_user = await utils.get_user_by_original_message(interaction.channel)
+        reset_code = await interaction.client.wom.reset_group_code(group_id)
+        new_code = reset_code.get("newCode") if reset_code is not None else None
+        if not isinstance(new_code, str):
+            await interaction.followup.send(
+                "Could not reset the group verification code.",
+                ephemeral=True,
+            )
+            return
+
+        channel = await _get_ticket_channel(interaction)
+        if channel is None:
+            return
+
+        ticket_user = await utils.get_user_by_original_message(channel)
+        if ticket_user is None:
+            await interaction.followup.send(
+                "Could not determine the ticket owner.",
+                ephemeral=True,
+            )
+            return
+
         await ticket_user.send(
-            f"Your verification code for group [{group_id}]({Config.DISCORD_BOT_BASE_WEBSITE_URL}/groups/{group_id}) has been reset.\n"
-            f"```{reset_code['newCode']}```"
-            f"Keep this code secret — it can be used to edit or delete your group."
+            f"Your verification code for group [{group_id}]"
+            f"({Config.DISCORD_BOT_BASE_WEBSITE_URL}/groups/{group_id}) has been reset.\n"
+            f"```{new_code}```"
+            "Keep this code secret - it can be used to edit or delete your group."
         )
         embed = discord.Embed(title="Reset Group Code", colour=discord.Colour.green())
         embed.add_field(name="Group ID", value=group_id)
-        embed.add_field(name="Group Name", value=data["name"])
-        embed.description = f"Verification code successfully reset. A DM has been sent to {ticket_user.mention}."
+        embed.add_field(name="Group Name", value=str(data["name"]))
+        embed.description = (
+            "Verification code successfully reset. "
+            f"A DM has been sent to {ticket_user.mention}."
+        )
         await interaction.followup.send(embed=embed)
 
     @discord.ui.button(
@@ -310,11 +436,13 @@ class ApproveDenyGroupRequest(discord.ui.View):
         custom_id="persistent_view:approve_deny_group_lookup",
     )
     async def group_lookup(
-        self: ViewT, interaction: discord.Interaction[Bot], _: discord.ui.Button[ViewT]
+        self: ViewT,
+        interaction: discord.Interaction[Bot],
+        _: discord.ui.Button[ViewT],
     ) -> None:
         await interaction.response.send_modal(GroupIdModal())
 
 
-async def setup(bot: commands.Bot) -> None:
+async def setup(bot: Bot) -> None:
     bot.add_view(ApproveDenyGroupRequest(group_id=""))
     bot.add_view(ApproveDenyPlayerRemoveRequest(rsn="", group_id="", group_name=""))

--- a/hom/cogs/group.py
+++ b/hom/cogs/group.py
@@ -29,7 +29,6 @@ class GroupIdModal(discord.ui.Modal, title="Group Lookup"):
             return
 
 
-
         embed = discord.Embed(
             title=f"Group Lookup",
             colour=discord.Colour.blue(),
@@ -45,7 +44,6 @@ class GroupIdModal(discord.ui.Modal, title="Group Lookup"):
         embed.add_field(name="Requested By", value=og_user.mention)
         embed.add_field(name="Requested By ID", value=og_user.id, inline=True)
         embed.add_field(name="Requested By Name", value=og_user.name, inline=True)
-
 
         await interaction.followup.send(embed=embed, view=ApproveDenyGroupRequest(self.group_id.value))
 
@@ -220,6 +218,7 @@ class ApproveDenyGroupRequest(discord.ui.View):
             mod=interaction.user,
         )
         await interaction.followup.send(embed=embed)
+        self.stop()
 
     @discord.ui.button(
         emoji="\N{CLOCKWISE RIGHTWARDS AND LEFTWARDS OPEN CIRCLE ARROWS}",

--- a/hom/cogs/group.py
+++ b/hom/cogs/group.py
@@ -94,14 +94,14 @@ class PlayerGroupModal(discord.ui.Modal, title="Player Lookup"):
     rsn = discord.ui.TextInput(
         label="Runescape Name",
         placeholder="Enter a username...",
-        default="PhyrWall",
+        default="",
         min_length=1,
         max_length=12,
     )
     group_id = discord.ui.TextInput(
         label="Group ID (listed on group's page)",
         placeholder="ex. 123",
-        default="1",
+        default="",
         min_length=1,
         max_length=6,
     )

--- a/hom/cogs/support.py
+++ b/hom/cogs/support.py
@@ -8,8 +8,7 @@ from discord.ext import commands
 from hom import utils
 from hom.bot import Bot
 from hom.cogs import views
-from hom.config import Config
-from hom.config import Constants
+from hom.config import Config, Constants
 
 __all__ = ("Support",)
 
@@ -56,7 +55,7 @@ class Support(commands.GroupCog, name="support"):
         await interaction.response.defer(ephemeral=True)
         assert interaction.guild
 
-        if not await self.mod_check(interaction):
+        if not await utils.mod_check(interaction):
             return None
 
         embed = utils.build_support_embed(interaction.guild)
@@ -75,19 +74,6 @@ class Support(commands.GroupCog, name="support"):
             return None
 
         await interaction.followup.send(view=views.Support())
-
-    async def mod_check(self, interaction: discord.Interaction[commands.Bot]) -> bool:
-        assert isinstance(interaction.user, discord.Member)
-
-        if not any(r.id == Config.MOD_ROLE for r in interaction.user.roles):
-            await interaction.followup.send(
-                f"{Constants.DENIED} You are not allowed to do that.",
-                ephemeral=True,
-            )
-
-            return False
-
-        return True
 
     async def category_check(
         self, interaction: discord.Interaction[commands.Bot], message: str, *, invert: bool = False
@@ -124,7 +110,7 @@ class Support(commands.GroupCog, name="support"):
         *,
         invert: bool = False,
     ) -> bool:
-        if not await self.mod_check(interaction):
+        if not await utils.mod_check(interaction):
             return False
 
         if not await self.category_check(interaction, category_message, invert=invert):

--- a/hom/cogs/support.py
+++ b/hom/cogs/support.py
@@ -8,7 +8,8 @@ from discord.ext import commands
 from hom import utils
 from hom.bot import Bot
 from hom.cogs import views
-from hom.config import Config, Constants
+from hom.config import Config
+from hom.config import Constants
 
 __all__ = ("Support",)
 

--- a/hom/cogs/views.py
+++ b/hom/cogs/views.py
@@ -4,6 +4,7 @@ from discord.ext import commands
 from hom import utils
 from hom.config import Config, Constants
 from hom.cogs.group import GroupIdModal, PlayerGroupModal
+from hom.utils import ViewT
 
 __all__ = (
     "GroupDetails",

--- a/hom/cogs/views.py
+++ b/hom/cogs/views.py
@@ -4,8 +4,10 @@ import discord
 from discord.ext import commands
 
 from hom import utils
-from hom.config import Config, Constants
-from hom.cogs.group import GroupIdModal, PlayerGroupModal
+from hom.cogs.group import GroupIdModal
+from hom.cogs.group import PlayerGroupModal
+from hom.config import Config
+from hom.config import Constants
 from hom.utils import ViewT
 
 __all__ = (
@@ -19,6 +21,7 @@ __all__ = (
     "SupportPlayer",
     "Verify",
 )
+
 
 class Support(discord.ui.View):
     def __init__(self) -> None:
@@ -39,7 +42,6 @@ class Support(discord.ui.View):
         )
         await asyncio.sleep(15)
         await (await interaction.original_response()).delete()
-
 
     @discord.ui.button(
         label="Competitions",
@@ -192,7 +194,7 @@ class SupportGroup(discord.ui.View):
                 instructions,
                 f"Groups {Constants.ARROW} {button.label}",
                 example_url="group.jpg",
-                view=GroupDetails()
+                view=GroupDetails(),
             )
         else:
             await utils.update_ticket_for_user(
@@ -200,7 +202,7 @@ class SupportGroup(discord.ui.View):
                 instructions,
                 f"Groups {Constants.ARROW} {button.label}",
                 example_url="group.jpg",
-                view = GroupDetails()
+                view=GroupDetails(),
             )
 
     @discord.ui.button(
@@ -234,7 +236,7 @@ class SupportGroup(discord.ui.View):
                 instructions,
                 f"Groups {Constants.ARROW} {button.label}",
                 example_url="group.jpg",
-                view=GroupDetails()
+                view=GroupDetails(),
             )
         else:
             await utils.update_ticket_for_user(
@@ -242,7 +244,7 @@ class SupportGroup(discord.ui.View):
                 instructions,
                 f"Groups {Constants.ARROW} {button.label}",
                 example_url="group.jpg",
-                view=GroupDetails()
+                view=GroupDetails(),
             )
 
     @discord.ui.button(
@@ -272,7 +274,7 @@ class SupportGroup(discord.ui.View):
                 instructions,
                 f"Groups {Constants.ARROW} {button.label}",
                 example_url="group.jpg",
-                view=GroupRemove()
+                view=GroupRemove(),
             )
         else:
             await utils.update_ticket_for_user(
@@ -280,7 +282,7 @@ class SupportGroup(discord.ui.View):
                 instructions,
                 f"Groups {Constants.ARROW} {button.label}",
                 example_url="group.jpg",
-                view=GroupRemove()
+                view=GroupRemove(),
             )
 
     @discord.ui.button(
@@ -710,6 +712,7 @@ class SupportMessageCloseChannel(discord.ui.View):
         )
         await interaction.channel.delete()
 
+
 class GroupRemove(discord.ui.View):
     def __init__(self) -> None:
         super().__init__(timeout=None)
@@ -744,6 +747,7 @@ class GroupRemove(discord.ui.View):
     ) -> None:
         await interaction.response.send_modal(PlayerGroupModal())
 
+
 class GroupDetails(discord.ui.View):
     def __init__(self) -> None:
         super().__init__(timeout=None)
@@ -764,7 +768,7 @@ class GroupDetails(discord.ui.View):
         await interaction.response.defer()
         await interaction.channel.set_permissions(interaction.user, overwrite=None)
         await interaction.followup.send(
-            ephemeral=False, embed=embed, view = SupportMessageCloseChannel()
+            ephemeral=False, embed=embed, view=SupportMessageCloseChannel()
         )
 
     @discord.ui.button(
@@ -779,6 +783,7 @@ class GroupDetails(discord.ui.View):
         _: discord.ui.Button[ViewT],
     ) -> None:
         await interaction.response.send_modal(GroupIdModal())
+
 
 async def setup(bot: commands.Bot) -> None:
     bot.add_view(GroupDetails())

--- a/hom/cogs/views.py
+++ b/hom/cogs/views.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import discord
 from discord.ext import commands
 
@@ -35,6 +37,9 @@ class Support(discord.ui.View):
             content="What do you need assistance with?",
             ephemeral=True,
         )
+        await asyncio.sleep(15)
+        await (await interaction.original_response()).delete()
+
 
     @discord.ui.button(
         label="Competitions",
@@ -49,6 +54,8 @@ class Support(discord.ui.View):
             content="What do you need assistance with?",
             ephemeral=True,
         )
+        await asyncio.sleep(15)
+        await (await interaction.original_response()).delete()
 
     @discord.ui.button(
         label="Players",
@@ -63,6 +70,8 @@ class Support(discord.ui.View):
             content="What do you need assistance with?",
             ephemeral=True,
         )
+        await asyncio.sleep(15)
+        await (await interaction.original_response()).delete()
 
     @discord.ui.button(
         label="Patreon", style=discord.ButtonStyle.green, custom_id="persistent_view:patreon"

--- a/hom/cogs/views.py
+++ b/hom/cogs/views.py
@@ -1,13 +1,13 @@
-import typing as t
-
 import discord
 from discord.ext import commands
 
 from hom import utils
-from hom.config import Config
-from hom.config import Constants
+from hom.config import Config, Constants
+from hom.cogs.group import GroupIdModal, PlayerGroupModal
 
 __all__ = (
+    "GroupDetails",
+    "GroupRemove",
     "Support",
     "SupportCompetition",
     "SupportGroup",
@@ -16,9 +16,6 @@ __all__ = (
     "SupportPlayer",
     "Verify",
 )
-
-ViewT = t.TypeVar("ViewT", bound=discord.ui.View)
-
 
 class Support(discord.ui.View):
     def __init__(self) -> None:
@@ -185,6 +182,7 @@ class SupportGroup(discord.ui.View):
                 instructions,
                 f"Groups {Constants.ARROW} {button.label}",
                 example_url="group.jpg",
+                view=GroupDetails()
             )
         else:
             await utils.update_ticket_for_user(
@@ -192,6 +190,7 @@ class SupportGroup(discord.ui.View):
                 instructions,
                 f"Groups {Constants.ARROW} {button.label}",
                 example_url="group.jpg",
+                view = GroupDetails()
             )
 
     @discord.ui.button(
@@ -225,6 +224,7 @@ class SupportGroup(discord.ui.View):
                 instructions,
                 f"Groups {Constants.ARROW} {button.label}",
                 example_url="group.jpg",
+                view=GroupDetails()
             )
         else:
             await utils.update_ticket_for_user(
@@ -232,6 +232,7 @@ class SupportGroup(discord.ui.View):
                 instructions,
                 f"Groups {Constants.ARROW} {button.label}",
                 example_url="group.jpg",
+                view=GroupDetails()
             )
 
     @discord.ui.button(
@@ -260,14 +261,16 @@ class SupportGroup(discord.ui.View):
                 interaction,
                 instructions,
                 f"Groups {Constants.ARROW} {button.label}",
-                example_url="player.jpg",
+                example_url="group.jpg",
+                view=GroupRemove()
             )
         else:
             await utils.update_ticket_for_user(
                 interaction,
                 instructions,
                 f"Groups {Constants.ARROW} {button.label}",
-                example_url="player.jpg",
+                example_url="group.jpg",
+                view=GroupRemove()
             )
 
     @discord.ui.button(
@@ -697,8 +700,79 @@ class SupportMessageCloseChannel(discord.ui.View):
         )
         await interaction.channel.delete()
 
+class GroupRemove(discord.ui.View):
+    def __init__(self) -> None:
+        super().__init__(timeout=None)
+
+    @discord.ui.button(
+        emoji="\N{LOCK}",
+        label="Close",
+        style=discord.ButtonStyle.blurple,
+        custom_id="persistent_view:message_close",
+    )
+    async def message_close(
+        self: ViewT, interaction: discord.Interaction[commands.Bot], _: discord.ui.Button[ViewT]
+    ) -> None:
+        assert isinstance(interaction.channel, discord.TextChannel)
+        assert isinstance(interaction.user, discord.Member)
+
+        embed = discord.Embed(description=f"{interaction.user.mention} has closed the ticket.")
+        await interaction.response.defer()
+        await interaction.channel.set_permissions(interaction.user, overwrite=None)
+        await interaction.followup.send(
+            ephemeral=False, embed=embed, view=SupportMessageCloseChannel()
+        )
+
+    @discord.ui.button(
+        emoji=f"{Constants.PEN}",
+        label="Player Lookup",
+        style=discord.ButtonStyle.blurple,
+        custom_id="persistent_view:player_details",  # must be unique
+    )
+    async def player_lookup(
+        self: ViewT, interaction: discord.Interaction[commands.Bot], _: discord.ui.Button[ViewT]
+    ) -> None:
+        await interaction.response.send_modal(PlayerGroupModal())
+
+class GroupDetails(discord.ui.View):
+    def __init__(self) -> None:
+        super().__init__(timeout=None)
+
+    @discord.ui.button(
+        emoji="\N{LOCK}",
+        label="Close",
+        style=discord.ButtonStyle.blurple,
+        custom_id="persistent_view:group_details_close",  # must be unique
+    )
+    async def message_close(
+        self: ViewT, interaction: discord.Interaction[commands.Bot], _: discord.ui.Button[ViewT]
+    ) -> None:
+        assert isinstance(interaction.channel, discord.TextChannel)
+        assert isinstance(interaction.user, discord.Member)
+
+        embed = discord.Embed(description=f"{interaction.user.mention} has closed the ticket.")
+        await interaction.response.defer()
+        await interaction.channel.set_permissions(interaction.user, overwrite=None)
+        await interaction.followup.send(
+            ephemeral=False, embed=embed, view = SupportMessageCloseChannel()
+        )
+
+    @discord.ui.button(
+        emoji=Constants.PEN,
+        label="Group Lookup",
+        style=discord.ButtonStyle.blurple,
+        custom_id="persistent_view:group_details_lookup",
+    )
+    async def group_details(
+        self: ViewT,
+        interaction: discord.Interaction[commands.Bot],
+        _: discord.ui.Button[ViewT],
+    ) -> None:
+        await interaction.response.send_modal(GroupIdModal())
 
 async def setup(bot: commands.Bot) -> None:
+    bot.add_view(GroupDetails())
+    bot.add_view(GroupRemove())
     bot.add_view(Support())
     bot.add_view(SupportCompetition())
     bot.add_view(SupportGroup())

--- a/hom/config.py
+++ b/hom/config.py
@@ -53,8 +53,8 @@ class Config:
     MOD_ROLE: t.Final[int] = _int("HOM_MOD_ROLE")
     GROUP_LEADER_ROLE: t.Final[int] = _int("HOM_GROUP_LEADER_ROLE")
     SHARED_ADMIN_PASSWORD: t.Final[str] = environ["SHARED_ADMIN_PASSWORD"]
-    DISCORD_BOT_BASE_API_URL: t.Final[str] = _container_host_url("HOM_DISCORD_BOT_BASE_API_URL")
-    DISCORD_BOT_BASE_WEBSITE_URL: t.Final[str] = environ["HOM_DISCORD_BOT_BASE_WEBSITE_URL"]
+    DISCORD_BOT_BASE_API_URL: t.Final[str] = _container_host_url("HOM_BASE_API_URL")
+    DISCORD_BOT_BASE_WEBSITE_URL: t.Final[str] = environ["HOM_BASE_WEBSITE_URL"]
     HOM_API_KEY: t.Final[str] = environ["HOM_API_KEY"]
 
     def __init__(self) -> None:

--- a/hom/config.py
+++ b/hom/config.py
@@ -1,7 +1,8 @@
 import typing as t
 from os import environ
 from pathlib import Path
-from urllib.parse import urlsplit, urlunsplit
+from urllib.parse import urlsplit
+from urllib.parse import urlunsplit
 
 from dotenv import load_dotenv
 
@@ -64,7 +65,10 @@ class Config:
 class Constants:
     __slots__ = ()
 
-    HEADERS: t.Final[t.Dict[str, str]] = {"userAgent": "Helpful Old Man Discord Bot","x-api-key":f'{Config.HOM_API_KEY}'}
+    HEADERS: t.Final[t.Dict[str, str]] = {
+        "userAgent": "Helpful Old Man Discord Bot",
+        "x-api-key": f"{Config.HOM_API_KEY}",
+    }
     ARROW: t.Final[str] = "→"
     PREFIX: t.Final[str] = "!"
     DENIED: t.Final[str] = "❌"
@@ -335,7 +339,6 @@ class Constants:
         "Zambia": "ZM",
         "Zimbabwe": "ZW",
     }
-
 
     def __init__(self) -> None:
         raise RuntimeError("Constants should not be instantiated.")

--- a/hom/config.py
+++ b/hom/config.py
@@ -54,6 +54,7 @@ class Config:
     SHARED_ADMIN_PASSWORD: t.Final[str] = environ["SHARED_ADMIN_PASSWORD"]
     DISCORD_BOT_BASE_API_URL: t.Final[str] = _container_host_url("DISCORD_BOT_BASE_API_URL")
     DISCORD_BOT_BASE_WEBSITE_URL: t.Final[str] = environ["DISCORD_BOT_BASE_WEBSITE_URL"]
+    HOM_API_KEY: t.Final[str] = environ["HOM_API_KEY"]
 
     def __init__(self) -> None:
         raise RuntimeError("Config should not be instantiated.")
@@ -63,7 +64,7 @@ class Config:
 class Constants:
     __slots__ = ()
 
-    HEADERS: t.Final[t.Dict[str, str]] = {"userAgent": "Helpful Old Man Discord Bot"}
+    HEADERS: t.Final[t.Dict[str, str]] = {"userAgent": "Helpful Old Man Discord Bot","x-api-key":f'{Config.HOM_API_KEY}'}
     ARROW: t.Final[str] = "→"
     PREFIX: t.Final[str] = "!"
     DENIED: t.Final[str] = "❌"

--- a/hom/config.py
+++ b/hom/config.py
@@ -24,8 +24,10 @@ class Config:
     QUESTIONS_CHANNEL: t.Final[int] = _int("HOM_QUESTIONS_CHANNEL")
     FLAG_CHANNEL: t.Final[int] = _int("HOM_FLAG_CHANNEL")
     MOD_ROLE: t.Final[int] = _int("HOM_MOD_ROLE")
+    GROUP_LEADER_ROLE: t.Final[int] = _int("HOM_GROUP_LEADER_ROLE")
     SHARED_ADMIN_PASSWORD: t.Final[str] = environ["SHARED_ADMIN_PASSWORD"]
     DISCORD_BOT_BASE_API_URL: t.Final[str] = environ["DISCORD_BOT_BASE_API_URL"]
+    DISCORD_BOT_BASE_WEBSITE_URL: t.Final[str] = environ["DISCORD_BOT_BASE_WEBSITE_URL"]
 
     def __init__(self) -> None:
         raise RuntimeError("Config should not be instantiated.")
@@ -35,10 +37,12 @@ class Config:
 class Constants:
     __slots__ = ()
 
+    HEADERS: t.Final[t.Dict[str, str]] = {"userAgent": "Helpful Old Man Discord Bot"}
     ARROW: t.Final[str] = "→"
     PREFIX: t.Final[str] = "!"
     DENIED: t.Final[str] = "❌"
     COMPLETE: t.Final[str] = "✅"
+    PEN: t.Final[str] = "📝"
     FOOTER: t.Final[str] = (
         "As a reminder, all moderators and admins in this "
         "server volunteer to assist in their free time. "
@@ -304,6 +308,7 @@ class Constants:
         "Zambia": "ZM",
         "Zimbabwe": "ZW",
     }
+
 
     def __init__(self) -> None:
         raise RuntimeError("Constants should not be instantiated.")

--- a/hom/config.py
+++ b/hom/config.py
@@ -53,8 +53,8 @@ class Config:
     MOD_ROLE: t.Final[int] = _int("HOM_MOD_ROLE")
     GROUP_LEADER_ROLE: t.Final[int] = _int("HOM_GROUP_LEADER_ROLE")
     SHARED_ADMIN_PASSWORD: t.Final[str] = environ["SHARED_ADMIN_PASSWORD"]
-    DISCORD_BOT_BASE_API_URL: t.Final[str] = _container_host_url("DISCORD_BOT_BASE_API_URL")
-    DISCORD_BOT_BASE_WEBSITE_URL: t.Final[str] = environ["DISCORD_BOT_BASE_WEBSITE_URL"]
+    DISCORD_BOT_BASE_API_URL: t.Final[str] = _container_host_url("HOM_DISCORD_BOT_BASE_API_URL")
+    DISCORD_BOT_BASE_WEBSITE_URL: t.Final[str] = environ["HOM_DISCORD_BOT_BASE_WEBSITE_URL"]
     HOM_API_KEY: t.Final[str] = environ["HOM_API_KEY"]
 
     def __init__(self) -> None:

--- a/hom/config.py
+++ b/hom/config.py
@@ -1,5 +1,7 @@
 import typing as t
 from os import environ
+from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
 
 from dotenv import load_dotenv
 
@@ -10,6 +12,30 @@ load_dotenv()
 
 def _int(var: str) -> int:
     return int(environ[var])
+
+
+def _running_in_docker() -> bool:
+    return Path("/.dockerenv").exists()
+
+
+def _container_host_url(var: str) -> str:
+    value = environ[var]
+    if not _running_in_docker():
+        return value
+
+    parsed = urlsplit(value)
+    if parsed.hostname not in {"localhost", "127.0.0.1"}:
+        return value
+
+    auth = ""
+    if parsed.username:
+        auth = parsed.username
+        if parsed.password:
+            auth += f":{parsed.password}"
+        auth += "@"
+
+    port = f":{parsed.port}" if parsed.port is not None else ""
+    return urlunsplit(parsed._replace(netloc=f"{auth}host.docker.internal{port}"))
 
 
 @t.final
@@ -26,7 +52,7 @@ class Config:
     MOD_ROLE: t.Final[int] = _int("HOM_MOD_ROLE")
     GROUP_LEADER_ROLE: t.Final[int] = _int("HOM_GROUP_LEADER_ROLE")
     SHARED_ADMIN_PASSWORD: t.Final[str] = environ["SHARED_ADMIN_PASSWORD"]
-    DISCORD_BOT_BASE_API_URL: t.Final[str] = environ["DISCORD_BOT_BASE_API_URL"]
+    DISCORD_BOT_BASE_API_URL: t.Final[str] = _container_host_url("DISCORD_BOT_BASE_API_URL")
     DISCORD_BOT_BASE_WEBSITE_URL: t.Final[str] = environ["DISCORD_BOT_BASE_WEBSITE_URL"]
 
     def __init__(self) -> None:

--- a/hom/utils.py
+++ b/hom/utils.py
@@ -9,6 +9,7 @@ import discord
 import requests
 from discord import app_commands
 from discord.ext import commands
+
 from hom.config import Config
 from hom.config import Constants
 
@@ -110,13 +111,14 @@ async def create_ticket_for_user(
     existing_ticket_channel = get_user_ticket_channel(interaction.guild, interaction.user)
     if existing_ticket_channel:
         msg_content = f":envelope:  Click [here]({existing_ticket_channel.jump_url}) to view your open ticket."
-        msg = await interaction.followup.send(content=msg_content, ephemeral=True)
+        msg = await interaction.followup.send(content=msg_content, ephemeral=True, wait=True)
         await asyncio.sleep(15)
         await msg.delete()
         return existing_ticket_channel
 
     channel_name = f"help-{interaction.user.display_name[:15]}"
     tickets_category = get_category(interaction.guild, Config.TICKET_CATEGORY)
+    bot_member = interaction.guild.me
     if not (mod_role := get_role(interaction.guild, Config.MOD_ROLE)):
         await interaction.followup.send("The moderator role is missing from the server.")
         raise RuntimeError(f"Couldn't find mod role with ID: {Config.MOD_ROLE}")
@@ -128,7 +130,7 @@ async def create_ticket_for_user(
         topic=button_label or "Unknown (This is a bug)",
         overwrites={
             mod_role: discord.PermissionOverwrite(read_messages=True),
-            interaction.guild.me: discord.PermissionOverwrite(read_messages=True),
+            bot_member: discord.PermissionOverwrite(read_messages=True),
             t.cast(discord.Member, interaction.user): discord.PermissionOverwrite(
                 read_messages=True
             ),
@@ -162,11 +164,9 @@ async def create_ticket_for_user(
             f"{interaction.user.mention}", embed=embed, view=ticket_view, file=file
         )
     else:
-        await new_text_channel.send(
-            f"{interaction.user.mention}", embed=embed, view=ticket_view
-        )
+        await new_text_channel.send(f"{interaction.user.mention}", embed=embed, view=ticket_view)
 
-    msg = await interaction.followup.send(content, ephemeral=True)
+    msg = await interaction.followup.send(content, ephemeral=True, wait=True)
     await asyncio.sleep(15)
     await msg.delete()
 

--- a/hom/utils.py
+++ b/hom/utils.py
@@ -8,7 +8,6 @@ import discord
 import requests
 from discord import app_commands
 from discord.ext import commands
-import hom.cogs as cogs
 from hom.config import Config
 from hom.config import Constants
 
@@ -31,6 +30,13 @@ __all__ = (
 )
 
 ViewT = t.TypeVar("ViewT", bound=discord.ui.View)
+
+
+def _default_ticket_view() -> discord.ui.View:
+    # Import lazily to avoid a module cycle during startup.
+    from hom.cogs.views import SupportMessage
+
+    return SupportMessage()
 
 
 async def archive_channel_messages(channel: discord.TextChannel) -> str:
@@ -145,7 +151,7 @@ async def create_ticket_for_user(
             "answered, feel free to close the ticket."
         )
     )
-    ticket_view = view or cogs.views.SupportMessage()
+    ticket_view = view or _default_ticket_view()
     if example_url:
         file = discord.File(f"hom/assets/{example_url}", filename=example_url)
         embed.set_image(url=f"attachment://{example_url}")
@@ -268,7 +274,7 @@ async def update_ticket_for_user(
             "answered, feel free to close the ticket."
         )
     )
-    ticket_view = view or views.SupportMessage()
+    ticket_view = view or _default_ticket_view()
     if example_url:
         file = discord.File(f"hom/assets/{example_url}", filename=example_url)
         embed.set_image(url=f"attachment://{example_url}")

--- a/hom/utils.py
+++ b/hom/utils.py
@@ -9,7 +9,6 @@ import requests
 from discord import app_commands
 from discord.ext import commands
 
-from hom.cogs import views
 from hom.config import Config
 from hom.config import Constants
 
@@ -25,10 +24,13 @@ __all__ = (
     "get_role",
     "get_user_by_original_message",
     "get_user_ticket_channel",
+    "mod_check",
     "send_log_message",
     "set_flag_autocomplete",
     "set_flag",
 )
+
+ViewT = t.TypeVar("ViewT", bound=discord.ui.View)
 
 
 async def archive_channel_messages(channel: discord.TextChannel) -> str:
@@ -94,6 +96,7 @@ async def create_ticket_for_user(
     instructions: str,
     button_label: t.Optional[str],
     example_url: t.Optional[str] = None,
+    view: t.Optional[discord.ui.View] = None,
 ) -> discord.TextChannel:
     assert interaction.guild
 
@@ -142,16 +145,16 @@ async def create_ticket_for_user(
             "answered, feel free to close the ticket."
         )
     )
-
+    ticket_view = view or views.SupportMessage()
     if example_url:
         file = discord.File(f"hom/assets/{example_url}", filename=example_url)
         embed.set_image(url=f"attachment://{example_url}")
         await new_text_channel.send(
-            f"{interaction.user.mention}", embed=embed, view=views.SupportMessage(), file=file
+            f"{interaction.user.mention}", embed=embed, view=ticket_view, file=file
         )
     else:
         await new_text_channel.send(
-            f"{interaction.user.mention}", embed=embed, view=views.SupportMessage()
+            f"{interaction.user.mention}", embed=embed, view=ticket_view
         )
 
     await interaction.followup.send(content, ephemeral=True)
@@ -245,6 +248,7 @@ async def update_ticket_for_user(
     instructions: str,
     button_label: t.Optional[str],
     example_url: t.Optional[str] = None,
+    view: t.Optional[discord.ui.View] = None,
 ) -> t.Optional[discord.Message]:
     assert interaction.guild
     assert isinstance(interaction.channel, discord.TextChannel)
@@ -264,7 +268,7 @@ async def update_ticket_for_user(
             "answered, feel free to close the ticket."
         )
     )
-
+    ticket_view = view or views.SupportMessage()
     if example_url:
         file = discord.File(f"hom/assets/{example_url}", filename=example_url)
         embed.set_image(url=f"attachment://{example_url}")
@@ -273,14 +277,14 @@ async def update_ticket_for_user(
         await interaction.channel.send(
             (f"Hey {og_user.mention}, please check the updated instructions."),
             embed=embed,
-            view=views.SupportMessage(),
+            view=ticket_view,
             file=file,
         )
     else:
         await interaction.channel.send(
             (f"Hey {og_user.mention}, please check the updated instructions."),
             embed=embed,
-            view=views.SupportMessage(),
+            view=ticket_view,
         )
 
     await interaction.edit_original_response(content="Updated ticket for user.", view=None)
@@ -292,6 +296,20 @@ async def update_ticket_for_user(
     assert interaction.client.user
     await send_log_message(interaction, log_content, mod=interaction.client.user)
     return message
+
+
+async def mod_check(interaction: discord.Interaction[commands.Bot]) -> bool:
+    assert isinstance(interaction.user, discord.Member)
+
+    if not any(r.id == Config.MOD_ROLE for r in interaction.user.roles):
+        await interaction.followup.send(
+            f"{Constants.DENIED} You are not allowed to do that.",
+            ephemeral=True,
+        )
+
+        return False
+
+    return True
 
 
 async def send_log_message(

--- a/hom/utils.py
+++ b/hom/utils.py
@@ -1,3 +1,4 @@
+import asyncio
 import datetime
 import functools
 import io
@@ -109,7 +110,9 @@ async def create_ticket_for_user(
     existing_ticket_channel = get_user_ticket_channel(interaction.guild, interaction.user)
     if existing_ticket_channel:
         msg_content = f":envelope:  Click [here]({existing_ticket_channel.jump_url}) to view your open ticket."
-        await interaction.followup.send(content=msg_content, ephemeral=True)
+        msg = await interaction.followup.send(content=msg_content, ephemeral=True)
+        await asyncio.sleep(15)
+        await msg.delete()
         return existing_ticket_channel
 
     channel_name = f"help-{interaction.user.display_name[:15]}"
@@ -163,7 +166,10 @@ async def create_ticket_for_user(
             f"{interaction.user.mention}", embed=embed, view=ticket_view
         )
 
-    await interaction.followup.send(content, ephemeral=True)
+    msg = await interaction.followup.send(content, ephemeral=True)
+    await asyncio.sleep(15)
+    await msg.delete()
+
     log_content = (
         f"({new_text_channel.topic}) Ticket opened for user:\n``{interaction.user.display_name}`` "
         f"- {interaction.user.mention}"

--- a/hom/utils.py
+++ b/hom/utils.py
@@ -8,7 +8,7 @@ import discord
 import requests
 from discord import app_commands
 from discord.ext import commands
-
+import hom.cogs as cogs
 from hom.config import Config
 from hom.config import Constants
 
@@ -145,7 +145,7 @@ async def create_ticket_for_user(
             "answered, feel free to close the ticket."
         )
     )
-    ticket_view = view or views.SupportMessage()
+    ticket_view = view or cogs.views.SupportMessage()
     if example_url:
         file = discord.File(f"hom/assets/{example_url}", filename=example_url)
         embed.set_image(url=f"attachment://{example_url}")

--- a/hom/wom.py
+++ b/hom/wom.py
@@ -1,17 +1,21 @@
 from typing import Any
+
 import aiohttp
-from hom.config import Config, Constants
+
+from hom.config import Config
+from hom.config import Constants
+
 
 class WomClient:
     def __init__(self, session: aiohttp.ClientSession) -> None:
-      self._session = session
-      self._base = Config.DISCORD_BOT_BASE_API_URL
+        self._session = session
+        self._base = Config.DISCORD_BOT_BASE_API_URL
 
     async def get_group(self, group_id: str | int) -> dict[str, Any] | None:
-      async with self._session.get(
-          f"{self._base}/groups/{group_id}", headers=Constants.HEADERS
-      ) as r:
-          return await r.json() if r.status == 200 else None
+        async with self._session.get(
+            f"{self._base}/groups/{group_id}", headers=Constants.HEADERS
+        ) as r:
+            return await r.json() if r.status == 200 else None
 
     async def verify_group(self, group_id: str) -> bool:
         async with self._session.put(
@@ -37,7 +41,7 @@ class WomClient:
         try:
             async with self._session.delete(
                 f"{self._base}/groups/{group_id}/members",
-                json={"members": [rsn],"adminPassword": Config.SHARED_ADMIN_PASSWORD},
+                json={"members": [rsn], "adminPassword": Config.SHARED_ADMIN_PASSWORD},
                 headers=Constants.HEADERS,
                 timeout=aiohttp.ClientTimeout(total=10),
             ) as r:

--- a/hom/wom.py
+++ b/hom/wom.py
@@ -1,4 +1,7 @@
 from typing import Any
+from typing import Dict
+from typing import Optional
+from typing import Union
 
 import aiohttp
 
@@ -11,7 +14,7 @@ class WomClient:
         self._session = session
         self._base = Config.DISCORD_BOT_BASE_API_URL
 
-    async def get_group(self, group_id: str | int) -> dict[str, Any] | None:
+    async def get_group(self, group_id: Union[str, int]) -> Optional[Dict[str, Any]]:
         async with self._session.get(
             f"{self._base}/groups/{group_id}", headers=Constants.HEADERS
         ) as r:
@@ -25,7 +28,7 @@ class WomClient:
         ) as r:
             return r.status == 200
 
-    async def reset_group_code(self, group_id: str | int) -> dict[str, Any] | None:
+    async def reset_group_code(self, group_id: Union[str, int]) -> Optional[Dict[str, Any]]:
         try:
             async with self._session.put(
                 f"{self._base}/groups/{group_id}/reset-code",
@@ -37,7 +40,9 @@ class WomClient:
         except (aiohttp.ClientError, TimeoutError):
             return None
 
-    async def remove_player_group(self, rsn: str, group_id: str | int) -> dict[str, Any] | None:
+    async def remove_player_group(
+        self, rsn: str, group_id: Union[str, int]
+    ) -> Optional[Dict[str, Any]]:
         try:
             async with self._session.delete(
                 f"{self._base}/groups/{group_id}/members",

--- a/hom/wom.py
+++ b/hom/wom.py
@@ -1,0 +1,46 @@
+from typing import Any
+import aiohttp
+from hom.config import Config, Constants
+
+class WomClient:
+    def __init__(self, session: aiohttp.ClientSession) -> None:
+      self._session = session
+      self._base = Config.DISCORD_BOT_BASE_API_URL
+
+    async def get_group(self, group_id: str | int) -> dict[str, Any] | None:
+      async with self._session.get(
+          f"{self._base}/groups/{group_id}", headers=Constants.HEADERS
+      ) as r:
+          return await r.json() if r.status == 200 else None
+
+    async def verify_group(self, group_id: str) -> bool:
+        async with self._session.put(
+            f"{self._base}/groups/{group_id}/verify",
+            json={"adminPassword": Config.SHARED_ADMIN_PASSWORD},
+            headers=Constants.HEADERS,
+        ) as r:
+            return r.status == 200
+
+    async def reset_group_code(self, group_id: str | int) -> dict[str, Any] | None:
+        try:
+            async with self._session.put(
+                f"{self._base}/groups/{group_id}/reset-code",
+                json={"adminPassword": Config.SHARED_ADMIN_PASSWORD},
+                headers=Constants.HEADERS,
+                timeout=aiohttp.ClientTimeout(total=10),
+            ) as r:
+                return await r.json() if r.status == 200 else None
+        except (aiohttp.ClientError, TimeoutError):
+            return None
+
+    async def remove_player_group(self, rsn: str, group_id: str | int) -> dict[str, Any] | None:
+        try:
+            async with self._session.delete(
+                f"{self._base}/groups/{group_id}/members",
+                json={"members": [rsn],"adminPassword": Config.SHARED_ADMIN_PASSWORD},
+                headers=Constants.HEADERS,
+                timeout=aiohttp.ClientTimeout(total=10),
+            ) as r:
+                return await r.json() if r.status == 200 else None
+        except (aiohttp.ClientError, TimeoutError):
+            return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,11 @@
 [tool.pyright]
 include = ["hom"]
+pythonVersion = "3.8"
 typeCheckingMode = "strict"
 
 [tool.mypy]
 packages = ["hom"]
+python_version = "3.8"
 strict = true
 
 [tool.isort]


### PR DESCRIPTION
  - Add group.py cog with modals and persistent views for group verification, group code reset, and player removal from a group; support tickets for group-related requests now use GroupDetails and GroupRemove views instead
  of the generic SupportMessage view
  - Add competition.py cog with a /competition remove_from_competitions command; supports removing a player from a single competition or all competitions in a group **YAY**, with autocomplete for both competition and group IDs
  based on the player's username
  - Add WomClient (wom.py) as an async  client for WOM API calls (get group, verify group, reset group code, remove player from group) - will add competitions to this later
  - Promote mod_check and ViewT from support.py/views.py into utils.py so all cogs share a single implementation
  - Add HOM_API_KEY and DISCORD_BOT_BASE_WEBSITE_URL to config; add Constants.HEADERS and Constants.PEN; add Docker-aware URL rewriting for localhost API URLs so the bot works in both local and containerized dev
  environments
  - Ephemeral followup messages in the support flow now auto-delete after 15 seconds