### PR TITLE
Competition lookup based on current competitions

### DIFF
--- a/hom/cogs/competition.py
+++ b/hom/cogs/competition.py
@@ -4,7 +4,6 @@ from typing import Optional
 from typing import Set
 
 import discord
-import requests
 from discord import app_commands
 from discord.ext import commands
 
@@ -31,14 +30,11 @@ class Competition(commands.GroupCog, name="competition"):
         if not username:
             return []
 
-        url = f"{Config.HOM_BASE_API_URL}/players/{username}/competitions"
+        data = await self.bot.wom.get_player_competitions(username)
 
-        response = requests.get(url=url, headers=Constants.HEADERS)
-
-        if response.status_code != 200:
+        if not data:
             return []
 
-        data = response.json()
         search = current.lower().strip()
         choices: List[app_commands.Choice[int]] = []
 
@@ -72,25 +68,20 @@ class Competition(commands.GroupCog, name="competition"):
         if not username:
             return []
 
-        url = f"{Config.HOM_BASE_API_URL}/players/{username}/groups"
+        data = await self.bot.wom.get_player_competitions(username)
 
-        response = requests.get(
-            url=url,
-            headers=Constants.HEADERS,
-        )
-
-        if response.status_code != 200:
+        if not data:
             return []
 
-        data = response.json()
         search = current.lower().strip()
         choices: List[app_commands.Choice[int]] = []
 
         seen: Set[int] = set()
 
         for entry in data:
-            group_id = entry.get("groupId")
-            group_name = entry.get("group", {}).get("name", "")
+            competition = entry.get("competition", {})
+            group_id = competition.get("groupId")
+            group_name = competition.get("group", {}).get("name", "")
 
             if not isinstance(group_id, int) or group_id in seen:
                 continue
@@ -160,63 +151,49 @@ class Competition(commands.GroupCog, name="competition"):
             competition_link = (
                 f"[{competition_id}]({Config.HOM_BASE_WEBSITE_URL}/competitions/{competition_id})"
             )
-            response = requests.delete(
-                url=f"{Config.HOM_BASE_API_URL}/competitions/{competition_id}/participants",
-                json={
-                    "participants": [username],
-                    "adminPassword": Config.SHARED_ADMIN_PASSWORD,
-                },
-                headers=Constants.HEADERS,
+            status, text = await self.bot.wom.remove_competition_participant(
+                competition_id, username
             )
 
-            if response.status_code != 200:
-                if "cannot remove all competition participants" in response.text.lower():
+            if status != 200:
+                if "cannot remove all competition participants" in text.lower():
                     skipped_competitions.append(competition_link)
-                elif "none of the players given were competing" in response.text.lower():
+                elif "none of the players given were competing" in text.lower():
                     skipped_competitions.append(competition_link + " (Player not found)")
                 else:
                     error_competitions.append(
-                        competition_link + f" {Constants.ARROW} ```{response.text}```"
+                        competition_link + f" {Constants.ARROW} ```{text}```"
                     )
             else:
                 successful_competitions.append(competition_link)
         else:
-            url = f"{Config.HOM_BASE_API_URL}/players/{username}/competitions"
-            response = requests.get(
-                url=url,
-                headers=Constants.HEADERS,
-            )
+            data = await self.bot.wom.get_player_competitions(username)
 
-            if response.status_code != 200:
+            if not data:
                 await interaction.followup.send(
                     f"Could not find any competitions related to the username: `{username}`."
                 )
                 return
 
-            for comp in response.json():
+            for comp in data:
                 comp_id = comp["competitionId"]
                 competition_link = (
                     f"[{comp_id}]({Config.HOM_BASE_WEBSITE_URL}/competitions/{comp_id})"
                 )
 
                 if group_id == comp["competition"]["groupId"]:
-                    response = requests.delete(
-                        url=f"{Config.HOM_BASE_API_URL}/competitions/{comp_id}/participants",
-                        json={
-                            "participants": [username],
-                            "adminPassword": Config.SHARED_ADMIN_PASSWORD,
-                        },
-                        headers=Constants.HEADERS,
+                    status, text = await self.bot.wom.remove_competition_participant(
+                        comp_id, username
                     )
 
-                    if response.status_code != 200:
-                        if "cannot remove all competition participants" in response.text.lower():
+                    if status != 200:
+                        if "cannot remove all competition participants" in text.lower():
                             skipped_competitions.append(competition_link)
-                        elif "none of the players given were competing" in response.text.lower():
+                        elif "none of the players given were competing" in text.lower():
                             skipped_competitions.append(competition_link + " (Player not found)")
                         else:
                             error_competitions.append(
-                                competition_link + f" {Constants.ARROW} ```{response.text}```"
+                                competition_link + f" {Constants.ARROW} ```{text}```"
                             )
                         continue
 

--- a/hom/cogs/competition.py
+++ b/hom/cogs/competition.py
@@ -9,7 +9,6 @@ from discord.ext import commands
 
 from hom import utils
 from hom.bot import Bot
-from hom.config import Config
 from hom.config import Constants
 
 __all__ = ("Competition",)
@@ -148,24 +147,14 @@ class Competition(commands.GroupCog, name="competition"):
         skipped_competitions: List[str] = []
 
         if competition_id is not None:
-            competition_link = (
-                f"[{competition_id}]({Config.HOM_BASE_WEBSITE_URL}/competitions/{competition_id})"
-            )
             status, text = await self.bot.wom.remove_competition_participant(
                 competition_id, username
             )
 
             if status != 200:
-                if "cannot remove all competition participants" in text.lower():
-                    skipped_competitions.append(competition_link)
-                elif "none of the players given were competing" in text.lower():
-                    skipped_competitions.append(competition_link + " (Player not found)")
-                else:
-                    error_competitions.append(
-                        competition_link + f" {Constants.ARROW} ```{text}```"
-                    )
+                error_competitions.append(str(competition_id))
             else:
-                successful_competitions.append(competition_link)
+                successful_competitions.append(str(competition_id))
         else:
             data = await self.bot.wom.get_player_competitions(username)
 
@@ -177,9 +166,6 @@ class Competition(commands.GroupCog, name="competition"):
 
             for comp in data:
                 comp_id = comp["competitionId"]
-                competition_link = (
-                    f"[{comp_id}]({Config.HOM_BASE_WEBSITE_URL}/competitions/{comp_id})"
-                )
 
                 if group_id == comp["competition"]["groupId"]:
                     status, text = await self.bot.wom.remove_competition_participant(
@@ -187,17 +173,16 @@ class Competition(commands.GroupCog, name="competition"):
                     )
 
                     if status != 200:
-                        if "cannot remove all competition participants" in text.lower():
-                            skipped_competitions.append(competition_link)
-                        elif "none of the players given were competing" in text.lower():
-                            skipped_competitions.append(competition_link + " (Player not found)")
+                        if (
+                            "cannot remove all competition participants" in text.lower()
+                            or "none of the players given were competing" in text.lower()
+                        ):
+                            skipped_competitions.append(str(comp_id))
                         else:
-                            error_competitions.append(
-                                competition_link + f" {Constants.ARROW} ```{text}```"
-                            )
+                            error_competitions.append(str(comp_id))
                         continue
 
-                    successful_competitions.append(competition_link)
+                    successful_competitions.append(str(comp_id))
 
         if not any([successful_competitions, error_competitions, skipped_competitions]):
             await interaction.followup.send(
@@ -207,7 +192,7 @@ class Competition(commands.GroupCog, name="competition"):
 
         embed = discord.Embed(
             title=f"Competition(s) removal for `{username}`",
-            color=Constants.BLUE,
+            color=Constants.GREEN,
         )
 
         embed.add_field(
@@ -215,6 +200,20 @@ class Competition(commands.GroupCog, name="competition"):
             value=f"Success Count: `{len(successful_competitions)}`\nSkipped Count: "
             f"`{len(skipped_competitions)}`\nError Count: `{len(error_competitions)}`",
         )
+
+        if len(skipped_competitions) > 0:
+            embed.add_field(
+                name="",
+                value=f"Skipped Competitons: `{', '.join(skipped_competitions)}`"[:1024],
+                inline=False,
+            )
+
+        if len(error_competitions) > 0:
+            embed.add_field(
+                name="",
+                value=f"Error Competiions: `{', '.join(error_competitions)}`"[:1024],
+                inline=False,
+            )
 
         await interaction.followup.send(embed=embed)
 

--- a/hom/wom.py
+++ b/hom/wom.py
@@ -1,6 +1,8 @@
 from typing import Any
 from typing import Dict
+from typing import List
 from typing import Optional
+from typing import Tuple
 from typing import Union
 
 import aiohttp
@@ -19,6 +21,28 @@ class WomClient:
             f"{self._base}/groups/{group_id}", headers=Constants.HEADERS
         ) as r:
             return await r.json() if r.status == 200 else None
+
+    async def get_player_competitions(self, username: str) -> Optional[List[Dict[str, Any]]]:
+        try:
+            async with self._session.get(
+                f"{self._base}/players/{username}/competitions",
+                headers=Constants.HEADERS,
+                timeout=aiohttp.ClientTimeout(total=10),
+            ) as r:
+                return await r.json() if r.status == 200 else None
+        except (aiohttp.ClientError, TimeoutError):
+            return None
+
+    async def remove_competition_participant(
+        self, competition_id: Union[str, int], rsn: str
+    ) -> Tuple[int, str]:
+        async with self._session.delete(
+            f"{self._base}/competitions/{competition_id}/participants",
+            json={"participants": [rsn], "adminPassword": Config.SHARED_ADMIN_PASSWORD},
+            headers=Constants.HEADERS,
+            timeout=aiohttp.ClientTimeout(total=10),
+        ) as r:
+            return r.status, await r.text()
 
     async def verify_group(self, group_id: str) -> bool:
         async with self._session.put(


### PR DESCRIPTION
* Fixed the competition lookup to search using the current group IDs associated with each competition, rather than the groups the player is currently a member of. This fixes an issue where players were asking to leave competition(s) for groups they had already left.
* Moved the API logic into the wom module.
